### PR TITLE
Zines

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ you can [see it live](https://nara.network) ([backup/debug site](https://global-
 **public info** is authoritative - you define your own status and broadcast it.
 **event store** is hearsay - things that happened, spread through gossip.
 
-events flow through the **plaza** (MQTT), where all naras watch in real-time. when a nara boots, it catches up by asking neighbors what it missed. then it watches live.
+events spread through two channels:
+- **plaza** (MQTT broadcast) - the public square where everyone hears announcements
+- **zines** (P2P gossip) - events passed hand-to-hand between neighbors via mesh
+
+naras can use MQTT-only (traditional), gossip-only (P2P), or hybrid (both). apps stay transport-agnostic - they don't know or care how events arrive. when a nara boots, it catches up by asking neighbors what it missed, then spreads and receives news organically.
 
 ```
 ledger (facts) → derivation function → opinions

--- a/SYNC.md
+++ b/SYNC.md
@@ -133,6 +133,35 @@ The transport layer automatically picks up events from SyncLedger and spreads th
 
 It's like some people use Twitter (MQTT - broadcast to all), some use Mastodon (gossip - federated P2P), and some use both - but they all see the same posts (SyncEvents).
 
+### Mesh Discovery (Gossip-Only Mode)
+
+In gossip-only mode (no MQTT), naras discover each other by scanning the mesh network:
+
+```
+Every 5 minutes:
+  1. Scan mesh subnet (100.64.0.1-254)
+  2. Try GET /ping on each IP
+  3. If successful, decode {"from": "nara-name", "t": timestamp}
+  4. Add discovered nara to neighborhood with mesh IP
+  5. Mark as ONLINE in observations
+```
+
+**Why IP scanning?**
+- No dependency on MQTT for discovery
+- Works in pure P2P networks
+- Automatically finds new naras joining the mesh
+- Minimal overhead (1 scan per 5 minutes)
+
+**Discovery flow:**
+1. Nara A boots in gossip-only mode
+2. After 35 seconds, runs initial mesh scan
+3. Discovers naras B, C, D via /ping responses
+4. Adds them to neighborhood with mesh IPs
+5. Starts gossiping zines with discovered neighbors
+6. Periodic re-scans every 5 minutes to find new peers
+
+**Note:** In hybrid mode, MQTT handles discovery and gossip is used only for event distribution. Discovery scans only run in pure gossip mode.
+
 ## Sync Protocol
 
 ### Boot Recovery (Getting Up to Speed)

--- a/cmd/nara/main.go
+++ b/cmd/nara/main.go
@@ -115,7 +115,9 @@ func main() {
 		*authKeyPtr = deobfuscate(defaultHeadscaleKeyEnc)
 	}
 
-	if *verbosePtr || *extraVerbosePtr {
+	if *extraVerbosePtr {
+		logrus.SetLevel(logrus.TraceLevel)
+	} else if *verbosePtr {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 

--- a/consensus_events_test.go
+++ b/consensus_events_test.go
@@ -95,10 +95,13 @@ func TestConsensusEvents_UptimeWeighting(t *testing.T) {
 
 	// Two observers with LOW uptime report StartTime=1000
 	// Total uptime for cluster 1000: 100 + 100 = 200
+	// Note: Sleep between events to ensure unique timestamps (restart events dedupe by content+timestamp)
 	event1 := NewRestartObservationEventWithUptime("observer-a", subject, 1000, 5, 100)
-	event2 := NewRestartObservationEventWithUptime("observer-b", subject, 1000, 5, 100)
 	ledger.AddEvent(event1)
+	time.Sleep(time.Microsecond) // Ensure different nanosecond timestamp
+	event2 := NewRestartObservationEventWithUptime("observer-b", subject, 1000, 5, 100)
 	ledger.AddEvent(event2)
+	time.Sleep(time.Microsecond)
 
 	// One observer with HIGH uptime reports StartTime=2000 (different cluster)
 	// Total uptime for cluster 2000: 10000

--- a/coordinate_maintenance.go
+++ b/coordinate_maintenance.go
@@ -135,7 +135,7 @@ func (network *Network) pingAndUpdateCoordinates(targetName string, config Vival
 	// Ping the peer
 	rtt, err := network.tsnetMesh.Ping(meshIP, network.meName(), 5*time.Second)
 	if err != nil {
-		logrus.Debugf("📍 Ping to %s failed: %v", targetName, err)
+		logrus.Infof("📍 Ping to %s failed: %v", targetName, err)
 		return
 	}
 

--- a/http.go
+++ b/http.go
@@ -77,10 +77,10 @@ func (network *Network) loggingMiddleware(path string, handler http.HandlerFunc)
 
 		// Log the request
 		if bodySummary != "" {
-			logrus.Debugf("📨 %s %s from %s [%s] → %d (%v)",
+			logrus.Infof("📨 %s %s from %s [%s] → %d (%v)",
 				r.Method, path, caller, bodySummary, wrapped.status, duration.Round(time.Millisecond))
 		} else {
-			logrus.Debugf("📨 %s %s from %s → %d (%v)",
+			logrus.Infof("📨 %s %s from %s → %d (%v)",
 				r.Method, path, caller, wrapped.status, duration.Round(time.Millisecond))
 		}
 	}

--- a/http.go
+++ b/http.go
@@ -725,11 +725,15 @@ func (network *Network) httpGossipZineHandler(w http.ResponseWriter, r *http.Req
 	// Create our zine to send back (bidirectional exchange)
 	myZine := network.createZine()
 	if myZine == nil {
-		// Even if we have no events, send empty zine
+		// Even if we have no events, send empty signed zine
 		myZine = &Zine{
 			From:      network.meName(),
 			CreatedAt: time.Now().Unix(),
 			Events:    []SyncEvent{},
+		}
+		// Sign the empty zine for consistency
+		if sig, err := signZine(myZine, network.local.Keypair); err == nil {
+			myZine.Signature = sig
 		}
 	}
 

--- a/http.go
+++ b/http.go
@@ -129,6 +129,7 @@ func (network *Network) createHTTPMux(includeUI bool) *http.ServeMux {
 	// Mesh endpoints - available on both local and mesh servers
 	// These require Ed25519 authentication (except /ping which needs to be fast)
 	mux.HandleFunc("/events/sync", network.loggingMiddleware("/events/sync", network.meshAuthMiddleware("/events/sync", network.httpEventsSyncHandler)))
+	mux.HandleFunc("/gossip/zine", network.loggingMiddleware("/gossip/zine", network.meshAuthMiddleware("/gossip/zine", network.httpGossipZineHandler)))
 	mux.HandleFunc("/world/relay", network.loggingMiddleware("/world/relay", network.meshAuthMiddleware("/world/relay", network.httpWorldRelayHandler)))
 	mux.HandleFunc("/ping", network.loggingMiddleware("/ping", network.httpPingHandler)) // No auth - latency critical
 	mux.HandleFunc("/coordinates", network.loggingMiddleware("/coordinates", network.httpCoordinatesHandler))
@@ -684,6 +685,57 @@ func (network *Network) httpEventsSyncHandler(w http.ResponseWriter, r *http.Req
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	json.NewEncoder(w).Encode(response)
+}
+
+// POST /gossip/zine - Bidirectional zine exchange for P2P event gossip
+// Receives a zine, merges events, returns our zine
+func (network *Network) httpGossipZineHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Decode incoming zine
+	var theirZine Zine
+	if err := json.NewDecoder(r.Body).Decode(&theirZine); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Validate basic fields
+	if theirZine.From == "" {
+		http.Error(w, "from is required", http.StatusBadRequest)
+		return
+	}
+
+	// Verify signature if we know their public key
+	pubKey := network.getPublicKeyForNara(theirZine.From)
+	if len(pubKey) > 0 && !verifyZine(&theirZine, pubKey) {
+		logrus.Warnf("📰 Invalid zine signature from %s, rejecting", theirZine.From)
+		http.Error(w, "Invalid signature", http.StatusForbidden)
+		return
+	}
+
+	// Merge their events into our ledger
+	added, warned := network.MergeSyncEventsWithVerification(theirZine.Events)
+	if added > 0 {
+		logrus.Debugf("📰 Received zine from %s: merged %d events (%d warned)", theirZine.From, added, warned)
+	}
+
+	// Create our zine to send back (bidirectional exchange)
+	myZine := network.createZine()
+	if myZine == nil {
+		// Even if we have no events, send empty zine
+		myZine = &Zine{
+			From:      network.meName(),
+			CreatedAt: time.Now().Unix(),
+			Events:    []SyncEvent{},
+		}
+	}
+
+	// Return our zine
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	json.NewEncoder(w).Encode(myZine)
 }
 
 // Network Coordinate HTTP handlers

--- a/integration_events_test.go
+++ b/integration_events_test.go
@@ -1,7 +1,9 @@
 package nara
 
 import (
+	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -471,4 +473,107 @@ func TestIntegration_MissingDetectionNotTooSensitive(t *testing.T) {
 	}
 
 	t.Logf("Missing detection sensitivity test complete")
+}
+
+// TestIntegration_TeasingDeduplication validates that when multiple naras see the same
+// event triggering a tease, only one of them actually teases (the others see it already happened).
+func TestIntegration_TeasingDeduplication(t *testing.T) {
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	// Create 3 naras that share a sync ledger (simulating they're all seeing the same events)
+	sharedLedger := NewSyncLedger(1000)
+
+	naras := make([]*LocalNara, 3)
+	// Different delays for each nara: 10ms, 50ms, 100ms
+	// This simulates the staggered timing that happens in production
+	delays := []time.Duration{10 * time.Millisecond, 50 * time.Millisecond, 100 * time.Millisecond}
+
+	for i := 0; i < 3; i++ {
+		name := fmt.Sprintf("observer-%d", i)
+		ln := NewLocalNara(name, testSoul(name), "", "", "", 50, 1000)
+		ln.SyncLedger = sharedLedger
+		ln.Network.TeaseState = NewTeaseState()
+		// Set deterministic delay for testing
+		delay := delays[i]
+		ln.Network.testTeaseDelay = &delay
+
+		// Not booting
+		me := ln.getMeObservation()
+		me.LastRestart = time.Now().Unix() - 300
+		me.LastSeen = time.Now().Unix()
+		ln.setMeObservation(me)
+
+		naras[i] = ln
+	}
+
+	target := "comeback-nara"
+
+	// Count teases before
+	countTeasesBefore := 0
+	for _, e := range sharedLedger.GetSocialEventsAbout(target) {
+		if e.Social != nil && e.Social.Type == "tease" && e.Social.Reason == ReasonComeback {
+			countTeasesBefore++
+		}
+	}
+
+	// All 3 naras see the same triggering event and try to tease concurrently
+	// Use a WaitGroup to wait for all goroutines to complete
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			naras[idx].Network.TeaseWithDelay(target, ReasonComeback)
+		}(i)
+	}
+
+	// Wait for all teasing attempts to complete
+	wg.Wait()
+
+	// Count teases after - should be exactly 1 (the first nara to finish their delay wins)
+	teaseCount := 0
+	for _, e := range sharedLedger.GetSocialEventsAbout(target) {
+		if e.Social != nil && e.Social.Type == "tease" && e.Social.Reason == ReasonComeback {
+			teaseCount++
+		}
+	}
+
+	newTeases := teaseCount - countTeasesBefore
+
+	// THE KEY ASSERTION: Only 1 tease should have been added, not 3
+	if newTeases != 1 {
+		t.Errorf("Expected exactly 1 tease (first nara wins), got %d teases", newTeases)
+		t.Log("Without deduplication, all 3 naras would tease simultaneously")
+	}
+
+	// Find which nara actually teased (the one with shortest delay wins)
+	var teaser string
+	for _, e := range sharedLedger.GetSocialEventsAbout(target) {
+		if e.Social != nil && e.Social.Type == "tease" && e.Social.Reason == ReasonComeback {
+			teaser = e.Social.Actor
+			break
+		}
+	}
+
+	// Verify hasRecentTeaseFor: naras who DIDN'T tease should see it, the teaser won't (it's their own)
+	for i := 0; i < 3; i++ {
+		hasRecent := naras[i].Network.hasRecentTeaseFor(target, ReasonComeback)
+		isTeaser := naras[i].Network.meName() == teaser
+		if isTeaser && hasRecent {
+			t.Errorf("observer-%d (the teaser) should NOT see their own tease via hasRecentTeaseFor", i)
+		}
+		if !isTeaser && !hasRecent {
+			t.Errorf("observer-%d should see the tease from %s", i, teaser)
+		}
+	}
+
+	// Verify different reason is NOT blocked
+	for i := 0; i < 3; i++ {
+		hasRecent := naras[i].Network.hasRecentTeaseFor(target, ReasonHighRestarts)
+		if hasRecent {
+			t.Errorf("observer-%d should NOT see a tease for different reason", i)
+		}
+	}
+
+	t.Logf("Teasing deduplication: 3 naras tried to tease, only %d actually did", newTeases)
 }

--- a/integration_gossip_test.go
+++ b/integration_gossip_test.go
@@ -1,0 +1,346 @@
+package nara
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// TestIntegration_GossipOnlyMode validates that naras can operate in gossip-only mode
+// without MQTT, spreading events purely via P2P zine exchanges
+func TestIntegration_GossipOnlyMode(t *testing.T) {
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	// Create 5 naras in gossip-only mode (no MQTT)
+	naras := make([]*LocalNara, 5)
+	for i := 0; i < 5; i++ {
+		ln := NewLocalNara("gossip-nara-"+string(rune('a'+i)), "test-soul", "", "", "", 50, 1000)
+		ln.Network.TransportMode = TransportGossip // Gossip-only mode
+
+		// Fake that they're not booting
+		me := ln.getMeObservation()
+		me.LastRestart = time.Now().Unix() - 200
+		me.LastSeen = time.Now().Unix()
+		ln.setMeObservation(me)
+
+		// Add all other naras as mesh neighbors (simulate mesh connectivity)
+		for j := 0; j < 5; j++ {
+			if i != j {
+				neighborName := "gossip-nara-" + string(rune('a'+j))
+				neighbor := NewNara(neighborName)
+				neighbor.Status.MeshIP = "100.64.0." + string(rune('1'+j)) // Fake mesh IPs
+				ln.Network.importNara(neighbor)
+				ln.setObservation(neighborName, NaraObservation{Online: "ONLINE"})
+			}
+		}
+
+		naras[i] = ln
+	}
+
+	// Nara 0 creates a social event
+	event := NewTeaseEvent(naras[0].Me.Name, "gossip-nara-b", "high restarts")
+	naras[0].SyncLedger.AddSocialEvent(event)
+
+	// Simulate gossip rounds - each nara gossips with neighbors
+	// In real code this happens via gossipForever() loop
+	for round := 0; round < 3; round++ {
+		for i := 0; i < 5; i++ {
+			// Create zine from nara i
+			zine := createTestZine(naras[i])
+
+			// Exchange with 2-3 random neighbors
+			for j := 0; j < 5; j++ {
+				if i != j && j%2 == 0 { // Simple pattern for test
+					// Merge zine into neighbor's ledger
+					for _, e := range zine.Events {
+						naras[j].SyncLedger.AddEvent(e)
+					}
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond) // Allow propagation
+	}
+
+	// Verify event propagated to most naras via gossip
+	propagatedCount := 0
+	for i := 0; i < 5; i++ {
+		events := naras[i].SyncLedger.GetEventsByService(ServiceSocial)
+		for _, e := range events {
+			if e.Social != nil && e.Social.Type == "tease" && e.Social.Target == "gossip-nara-b" {
+				propagatedCount++
+				break
+			}
+		}
+	}
+
+	// Should reach at least 3/5 naras via gossip (epidemic spread)
+	if propagatedCount < 3 {
+		t.Errorf("Expected event to reach at least 3 naras via gossip, reached %d", propagatedCount)
+	}
+
+	t.Logf("✅ Gossip-only mode: event reached %d/5 naras without MQTT", propagatedCount)
+}
+
+// TestIntegration_HybridMode validates that naras can use both MQTT and gossip simultaneously
+func TestIntegration_HybridMode(t *testing.T) {
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	// Create shared ledger to simulate both transport paths
+	sharedLedger := NewSyncLedger(1000)
+
+	// Create 3 naras in hybrid mode
+	naras := make([]*LocalNara, 3)
+	for i := 0; i < 3; i++ {
+		ln := NewLocalNara("hybrid-nara-"+string(rune('a'+i)), "test-soul", "", "", "", 50, 1000)
+		ln.Network.TransportMode = TransportHybrid // Both MQTT and Gossip
+		ln.SyncLedger = sharedLedger               // Share ledger to simulate both paths working
+
+		// Fake not booting
+		me := ln.getMeObservation()
+		me.LastRestart = time.Now().Unix() - 200
+		me.LastSeen = time.Now().Unix()
+		ln.setMeObservation(me)
+
+		naras[i] = ln
+	}
+
+	// Create events via both "transports" (simulated)
+	mqttEvent := NewTeaseEvent("hybrid-nara-a", "hybrid-nara-b", "came back")
+	gossipEvent := NewTeaseEvent("hybrid-nara-b", "hybrid-nara-c", "trend abandon")
+
+	// Both should arrive in the shared ledger
+	sharedLedger.AddSocialEvent(mqttEvent)
+	sharedLedger.AddSocialEvent(gossipEvent)
+
+	// All naras should see both events (transport-agnostic)
+	for i := 0; i < 3; i++ {
+		events := naras[i].SyncLedger.GetEventsByService(ServiceSocial)
+		if len(events) < 2 {
+			t.Errorf("Nara %d expected to see 2 events (from both transports), got %d", i, len(events))
+		}
+	}
+
+	t.Logf("✅ Hybrid mode: all naras saw events from both MQTT and gossip transports")
+}
+
+// TestIntegration_MixedNetworkTopology validates that MQTT-only, gossip-only, and hybrid naras
+// can coexist and events still propagate across the network
+func TestIntegration_MixedNetworkTopology(t *testing.T) {
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	// Shared ledger simulates universal event propagation
+	sharedLedger := NewSyncLedger(2000)
+
+	// Create mixed network:
+	// - 2 MQTT-only naras
+	// - 2 Gossip-only naras
+	// - 2 Hybrid naras (bridge between MQTT and gossip)
+	naras := make([]*LocalNara, 6)
+	modes := []TransportMode{TransportMQTT, TransportMQTT, TransportGossip, TransportGossip, TransportHybrid, TransportHybrid}
+
+	for i := 0; i < 6; i++ {
+		ln := NewLocalNara("mixed-nara-"+string(rune('a'+i)), "test-soul", "", "", "", 50, 1000)
+		ln.Network.TransportMode = modes[i]
+		ln.SyncLedger = sharedLedger
+
+		me := ln.getMeObservation()
+		me.LastRestart = time.Now().Unix() - 200
+		me.LastSeen = time.Now().Unix()
+		ln.setMeObservation(me)
+
+		naras[i] = ln
+	}
+
+	// MQTT-only nara creates event (should propagate via hybrid bridges)
+	mqttEvent := NewTeaseEvent("mixed-nara-a", "mixed-nara-c", "high restarts")
+	sharedLedger.AddSocialEvent(mqttEvent)
+
+	// Gossip-only nara creates event (should propagate via hybrid bridges)
+	gossipEvent := NewTeaseEvent("mixed-nara-c", "mixed-nara-a", "came back")
+	sharedLedger.AddSocialEvent(gossipEvent)
+
+	// All naras should eventually see both events (hybrid naras bridge the gap)
+	time.Sleep(200 * time.Millisecond)
+
+	for i := 0; i < 6; i++ {
+		events := naras[i].SyncLedger.GetEventsByService(ServiceSocial)
+		if len(events) < 2 {
+			t.Errorf("Nara %d (mode: %v) expected to see 2 events, got %d", i, modes[i], len(events))
+		}
+	}
+
+	t.Logf("✅ Mixed topology: MQTT-only, gossip-only, and hybrid naras all saw both events")
+}
+
+// TestIntegration_ZineCreationAndExchange validates zine structure and bidirectional exchange
+func TestIntegration_ZineCreationAndExchange(t *testing.T) {
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	// Create 2 naras
+	alice := NewLocalNara("alice", "alice-soul", "", "", "", 50, 1000)
+	bob := NewLocalNara("bob", "bob-soul", "", "", "", 50, 1000)
+
+	// Alice creates some events
+	for i := 0; i < 5; i++ {
+		event := NewTeaseEvent("alice", "bob", "test")
+		alice.SyncLedger.AddSocialEvent(event)
+	}
+
+	// Alice creates a zine
+	aliceZine := createTestZine(alice)
+
+	// Verify zine structure
+	if aliceZine.From != "alice" {
+		t.Errorf("Expected zine from alice, got %s", aliceZine.From)
+	}
+	if len(aliceZine.Events) == 0 {
+		t.Error("Expected zine to contain events")
+	}
+	if aliceZine.CreatedAt == 0 {
+		t.Error("Expected zine to have creation timestamp")
+	}
+
+	// Bob receives alice's zine and merges events
+	for _, e := range aliceZine.Events {
+		bob.SyncLedger.AddEvent(e) // AddEvent for SyncEvent is correct
+	}
+
+	// Bob creates his own zine to send back (bidirectional exchange)
+	event := NewTeaseEvent("bob", "alice", "response")
+	bob.SyncLedger.AddSocialEvent(event)
+	bobZine := createTestZine(bob)
+
+	// Alice receives bob's zine
+	for _, e := range bobZine.Events {
+		alice.SyncLedger.AddEvent(e) // AddEvent for SyncEvent is correct
+	}
+
+	// Verify bidirectional exchange worked
+	aliceEvents := alice.SyncLedger.GetEventsByService(ServiceSocial)
+	bobEvents := bob.SyncLedger.GetEventsByService(ServiceSocial)
+
+	if len(bobEvents) < 5 {
+		t.Errorf("Bob should have received alice's 5 events, got %d", len(bobEvents))
+	}
+	if len(aliceEvents) < 6 { // original 5 + bob's 1
+		t.Errorf("Alice should have 6 events total (5 original + 1 from bob), got %d", len(aliceEvents))
+	}
+
+	t.Logf("✅ Zine exchange: bidirectional propagation working correctly")
+}
+
+// TestIntegration_GossipTargetSelection validates that gossip picks random mesh neighbors
+func TestIntegration_GossipTargetSelection(t *testing.T) {
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	ln := NewLocalNara("test-nara", "test-soul", "", "", "", 50, 1000)
+
+	// Add 10 mesh-enabled neighbors
+	for i := 0; i < 10; i++ {
+		neighborName := "neighbor-" + string(rune('a'+i))
+		neighbor := NewNara(neighborName)
+		neighbor.Status.MeshIP = "100.64.0." + string(rune('1'+i))
+		ln.Network.importNara(neighbor)
+		ln.setObservation(neighborName, NaraObservation{Online: "ONLINE"})
+	}
+
+	// Select gossip targets multiple times
+	selections := make(map[string]int)
+	for i := 0; i < 50; i++ {
+		targets := selectGossipTargets(ln.Network, 3)
+		for _, target := range targets {
+			selections[target]++
+		}
+	}
+
+	// Verify randomness: each neighbor should be selected at least once
+	if len(selections) < 5 { // Should hit at least half the neighbors
+		t.Errorf("Expected gossip to select diverse neighbors, only selected %d unique targets", len(selections))
+	}
+
+	t.Logf("✅ Gossip target selection: selected %d unique neighbors across 50 rounds", len(selections))
+}
+
+// TestIntegration_GossipEventDeduplication validates that duplicate events arriving
+// via both MQTT and gossip are deduplicated automatically
+func TestIntegration_GossipEventDeduplication(t *testing.T) {
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	ledger := NewSyncLedger(1000)
+
+	// Create event
+	event := NewTeaseEvent("alice", "bob", "high restarts")
+
+	// Add same event multiple times (simulating arrival via MQTT and gossip)
+	added1 := ledger.AddSocialEvent(event)
+	added2 := ledger.AddSocialEvent(event) // Duplicate
+	added3 := ledger.AddSocialEvent(event) // Duplicate
+
+	// First should succeed, duplicates should be rejected
+	if !added1 {
+		t.Error("First event should be added")
+	}
+	if added2 || added3 {
+		t.Error("Duplicate events should be rejected")
+	}
+
+	// Verify only one event in ledger
+	events := ledger.GetEventsByService(ServiceSocial)
+	if len(events) != 1 {
+		t.Errorf("Expected 1 event after deduplication, got %d", len(events))
+	}
+
+	t.Logf("✅ Event deduplication: same event via multiple transports correctly deduplicated")
+}
+
+// Helper: createTestZine creates a zine from a nara's recent events
+func createTestZine(ln *LocalNara) *Zine {
+	// Get recent events (last 5 minutes for test purposes)
+	cutoff := time.Now().Add(-5 * time.Minute).UnixNano()
+	allEvents := ln.SyncLedger.GetAllEvents()
+
+	var recentEvents []SyncEvent
+	for _, e := range allEvents {
+		if e.Timestamp >= cutoff {
+			recentEvents = append(recentEvents, e)
+		}
+	}
+
+	return &Zine{
+		From:      ln.Me.Name,
+		CreatedAt: time.Now().Unix(),
+		Events:    recentEvents,
+	}
+}
+
+// Helper: selectGossipTargets selects random mesh neighbors for gossip
+// (This will be implemented properly in the actual code)
+func selectGossipTargets(network *Network, count int) []string {
+	online := network.NeighbourhoodOnlineNames()
+
+	// Filter to mesh-enabled only
+	var meshEnabled []string
+	for _, name := range online {
+		if network.getMeshIPForNara(name) != "" {
+			meshEnabled = append(meshEnabled, name)
+		}
+	}
+
+	// Return random subset
+	if len(meshEnabled) <= count {
+		return meshEnabled
+	}
+
+	// Simple random selection for test
+	targets := make([]string, 0, count)
+	used := make(map[int]bool)
+	for len(targets) < count && len(targets) < len(meshEnabled) {
+		idx := len(meshEnabled) / (count + 1) * (len(targets) + 1)
+		if !used[idx] {
+			targets = append(targets, meshEnabled[idx])
+			used[idx] = true
+		}
+	}
+	return targets
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -57,10 +57,11 @@ func TestIntegration_MultiNaraNetwork(t *testing.T) {
 
 		// Start the nara (this spawns all goroutines)
 		go ln.Start(
-			false, // don't serve UI
-			false, // not read-only
-			"",    // no HTTP addr
-			nil,   // no mesh
+			false,         // don't serve UI
+			false,         // not read-only
+			"",            // no HTTP addr
+			nil,           // no mesh
+			TransportMQTT, // MQTT-only for integration tests (no mesh)
 		)
 
 		t.Logf("✅ Started %s (personality: A=%d S=%d C=%d)",

--- a/mesh.go
+++ b/mesh.go
@@ -18,6 +18,12 @@ import (
 	"tailscale.com/tsnet"
 )
 
+// TsnetPeer represents a peer discovered from the tsnet Status API
+type TsnetPeer struct {
+	Name string // Hostname (e.g., "blue-jay")
+	IP   string // Tailscale IP (e.g., "100.64.0.93")
+}
+
 // MeshTransport defines the interface for mesh network communication
 type MeshTransport interface {
 	// Send sends a message to a specific nara
@@ -332,6 +338,44 @@ func (t *TsnetMesh) Start(ctx context.Context) error {
 // IP returns the tailscale IP address of this mesh node
 func (t *TsnetMesh) IP() string {
 	return t.myIP
+}
+
+// Peers returns the list of peers from the tsnet Status API
+// This is much faster than scanning IPs since tsnet already knows its peers
+func (t *TsnetMesh) Peers(ctx context.Context) ([]TsnetPeer, error) {
+	if t.server == nil {
+		return nil, errors.New("tsnet server not initialized")
+	}
+
+	lc, err := t.server.LocalClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get local client: %w", err)
+	}
+
+	status, err := lc.Status(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get status: %w", err)
+	}
+
+	var peers []TsnetPeer
+	for _, peer := range status.Peer {
+		// Skip peers without IPs
+		if len(peer.TailscaleIPs) == 0 {
+			continue
+		}
+		// Use hostname (without domain suffix)
+		name := peer.HostName
+		if name == "" {
+			continue
+		}
+		peers = append(peers, TsnetPeer{
+			Name: name,
+			IP:   peer.TailscaleIPs[0].String(),
+		})
+	}
+
+	logrus.Debugf("📡 Got %d peers from tsnet Status API", len(peers))
+	return peers, nil
 }
 
 // Send is deprecated - world messages now use HTTP via HTTPMeshTransport

--- a/mesh.go
+++ b/mesh.go
@@ -82,7 +82,7 @@ func (t *HTTPMeshTransport) Send(target string, msg *WorldMessage) error {
 	client := t.tsnetServer.HTTPClient()
 	client.Timeout = 30 * time.Second
 
-	logrus.Debugf("🌍 Sending world message to %s via HTTP", target)
+	logrus.Infof("🌍 Sending world message to %s via HTTP", target)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send world message to %s: %w", target, err)
@@ -94,7 +94,7 @@ func (t *HTTPMeshTransport) Send(target string, msg *WorldMessage) error {
 		return fmt.Errorf("world relay to %s failed with status %d: %s", target, resp.StatusCode, string(body))
 	}
 
-	logrus.Debugf("🌍 World message sent to %s successfully", target)
+	logrus.Infof("🌍 World message sent to %s successfully", target)
 	return nil
 }
 

--- a/nara.go
+++ b/nara.go
@@ -120,8 +120,9 @@ func NewNara(name string) *Nara {
 	return nara
 }
 
-func (ln *LocalNara) Start(serveUI bool, readOnly bool, httpAddr string, meshConfig *TsnetConfig) {
+func (ln *LocalNara) Start(serveUI bool, readOnly bool, httpAddr string, meshConfig *TsnetConfig, transportMode TransportMode) {
 	ln.Network.ReadOnly = readOnly
+	ln.Network.TransportMode = transportMode
 	if serveUI {
 		logrus.Printf("💻 Serving UI")
 	}

--- a/network.go
+++ b/network.go
@@ -321,7 +321,7 @@ func (network *Network) getPublicKeyForNara(name string) []byte {
 // The event is always added regardless - verification is informational
 func (network *Network) VerifySyncEvent(e *SyncEvent) bool {
 	if !e.IsSigned() {
-		logrus.Debugf("Unsigned event %s from service %s (actor: %s)", e.ID[:8], e.Service, e.GetActor())
+		logrus.Tracef("Unsigned event %s from service %s (actor: %s)", e.ID[:8], e.Service, e.GetActor())
 		return true // Unsigned is acceptable, just log it
 	}
 
@@ -337,7 +337,7 @@ func (network *Network) VerifySyncEvent(e *SyncEvent) bool {
 		return false // Bad signature - suspicious
 	}
 
-	logrus.Debugf("Verified event %s from %s", e.ID[:8], e.Emitter)
+	logrus.Tracef("Verified event %s from %s", e.ID[:8], e.Emitter)
 	return true
 }
 

--- a/observations.go
+++ b/observations.go
@@ -317,7 +317,7 @@ func (network *Network) recordObservationOnlineNara(name string) {
 		if useObservationEvents() && !network.local.isBooting() && network.local.SyncLedger != nil {
 			event := NewFirstSeenObservationEvent(network.meName(), name, time.Now().Unix())
 			network.local.SyncLedger.AddEventWithDedup(event)
-			logrus.Debugf("📊 First-seen observation event: %s", name)
+			logrus.Infof("📊 First-seen observation event: %s", name)
 		}
 	}
 
@@ -356,7 +356,7 @@ func (network *Network) recordObservationOnlineNara(name string) {
 		if useObservationEvents() && !network.local.isBooting() && network.local.SyncLedger != nil && name != network.meName() {
 			event := NewRestartObservationEvent(network.meName(), name, observation.StartTime, observation.Restarts)
 			network.local.SyncLedger.AddEventWithDedup(event)
-			logrus.Debugf("📊 Restart observation event: %s (restart #%d)", name, observation.Restarts)
+			logrus.Infof("📊 Restart observation event: %s (restart #%d)", name, observation.Restarts)
 		}
 	}
 
@@ -373,7 +373,7 @@ func (network *Network) recordObservationOnlineNara(name string) {
 			if useObservationEvents() {
 				event := NewStatusChangeObservationEvent(network.meName(), name, "ONLINE")
 				network.local.SyncLedger.AddEventFiltered(event, network.local.Me.Status.Personality)
-				logrus.Debugf("📊 Status-change observation event: %s → ONLINE", name)
+				logrus.Infof("📊 Status-change observation event: %s → ONLINE", name)
 			} else {
 				// Legacy: State changed from MISSING/OFFLINE to ONLINE
 				event := NewObservationEvent(network.meName(), name, ReasonOnline)
@@ -534,7 +534,7 @@ func (network *Network) reportMissingWithDelay(subject string) {
 	if useObservationEvents() {
 		event := NewStatusChangeObservationEvent(network.meName(), subject, "MISSING")
 		network.local.SyncLedger.AddEventFiltered(event, network.local.Me.Status.Personality)
-		logrus.Debugf("📊 Status-change observation event: %s → MISSING (after %v delay)", subject, delay)
+		logrus.Infof("📊 Status-change observation event: %s → MISSING (after %v delay)", subject, delay)
 	} else {
 		// Legacy mode
 		event := NewObservationEvent(network.meName(), subject, ReasonOffline)

--- a/social.go
+++ b/social.go
@@ -113,7 +113,7 @@ func TeaseResonates(event SocialEvent, observerSoul string, observerPersonality 
 // NewTeaseEvent creates a new tease social event
 func NewTeaseEvent(actor, target, reason string) SocialEvent {
 	event := SocialEvent{
-		Timestamp: time.Now().Unix(),
+		Timestamp: time.Now().UnixNano(),
 		Type:      "tease",
 		Actor:     actor,
 		Target:    target,
@@ -127,7 +127,7 @@ func NewTeaseEvent(actor, target, reason string) SocialEvent {
 // Type is "observation" for system observations (online/offline, etc.)
 func NewObservationEvent(actor, target, reason string) SocialEvent {
 	event := SocialEvent{
-		Timestamp: time.Now().Unix(),
+		Timestamp: time.Now().UnixNano(),
 		Type:      "observation",
 		Actor:     actor,
 		Target:    target,
@@ -141,7 +141,7 @@ func NewObservationEvent(actor, target, reason string) SocialEvent {
 // The journeyID is stored in the Witness field for tracking
 func NewJourneyObservationEvent(observer, journeyOriginator, reason string, journeyID string) SocialEvent {
 	event := SocialEvent{
-		Timestamp: time.Now().Unix(),
+		Timestamp: time.Now().UnixNano(),
 		Type:      "observation",
 		Actor:     observer,
 		Target:    journeyOriginator,


### PR DESCRIPTION
This pull request introduces a new peer-to-peer (P2P) event gossip mechanism called "zines," adds support for configurable transport modes (MQTT, gossip, or hybrid), and updates documentation and code to reflect these capabilities. The changes make the event distribution layer more scalable and resilient, allowing naras to operate in different network environments and seamlessly bridge between traditional MQTT broadcast and decentralized gossip.

**Transport and Gossip System Enhancements:**

* Added a new `transport` command-line flag and corresponding logic to select between MQTT, gossip, or hybrid transport modes, with defaults and validation (`main.go`, `nara.go`). [[1]](diffhunk://#diff-70c203672bd085eb929cb622bc41c55991ba928a62e612ab198c22ba4e205467R97) [[2]](diffhunk://#diff-70c203672bd085eb929cb622bc41c55991ba928a62e612ab198c22ba4e205467R132-R135) [[3]](diffhunk://#diff-70c203672bd085eb929cb622bc41c55991ba928a62e612ab198c22ba4e205467L154-R159) [[4]](diffhunk://#diff-70c203672bd085eb929cb622bc41c55991ba928a62e612ab198c22ba4e205467R204-R230) [[5]](diffhunk://#diff-9477468a469e422e6a26bf9c46b77526a49bdbe6dd9a0f69c21e76b320ec5a07L123-R125)
* Introduced `TransportMode` field in the network, ensuring the selected mode is respected throughout the application. [[1]](diffhunk://#diff-9477468a469e422e6a26bf9c46b77526a49bdbe6dd9a0f69c21e76b320ec5a07L123-R125) [[2]](diffhunk://#diff-ed1088fda4ca38792b99302b355705eb525017fca294e83858422bb430d8cc59R64)

**P2P Gossip ("Zines") Implementation:**

* Implemented the `/gossip/zine` HTTP endpoint for bidirectional zine exchange, enabling P2P event distribution and merging received events into the local ledger (`http.go`). [[1]](diffhunk://#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48R132) [[2]](diffhunk://#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48R690-R740)

**Documentation Updates:**

* Expanded `README.md` and `SYNC.md` to document the new zine-based event gossip system, transport modes, and mesh-based discovery, providing clear explanations and rationale for each mode. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R32) [[2]](diffhunk://#diff-3d99e517d949327c5f8ff76084a636433efa693d73b43f35d10bf17f96808e02R80-R164)

These changes collectively make the system more flexible and robust, supporting both centralized and decentralized event propagation while keeping the application logic transport-agnostic.