### PR TITLE
add way to store arbitrary data in the network

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,9 @@
       "Bash(git log:*)",
       "Bash(go build:*)",
       "Bash(wc:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Bash(make test-fast:*)",
+      "Bash(go test:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,13 @@
       "Bash(grep:*)",
       "Bash(make test-fast:*)",
       "Bash(go test:*)",
-      "Bash(go clean:*)"
+      "Bash(go clean:*)",
+      "Skill(code-review:code-review)",
+      "Bash(git grep:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(make test:*)",
+      "Bash(go vet:*)",
+      "Bash(goimports:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,8 @@
       "Bash(wc:*)",
       "Bash(grep:*)",
       "Bash(make test-fast:*)",
-      "Bash(go test:*)"
+      "Bash(go test:*)",
+      "Bash(go clean:*)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,14 @@ Same events + same personality = same opinions (deterministic).
    - `mqtt.go` - MQTT broker connectivity (Plaza broadcasts)
    - `mesh.go` - Tailscale/Headscale P2P networking (Zine gossip)
    - `network.go` - Core network coordination
-5. **Social** (`social.go`, `teasing_test.go`) - Teasing, trends, clout
-6. **Observations** (`observations.go`) - Distributed consensus on network state
+5. **Stash** (`stash.go`, `stash_sync_tracker.go`) - Distributed encrypted storage:
+   - HTTP-based bidirectional exchange (piggybacks on gossip)
+   - Memory-only storage (no disk persistence)
+   - Memory-aware limits (5/20/50 based on memory mode)
+   - Smart confidant selection (prefer high memory + uptime)
+   - XChaCha20-Poly1305 encryption (owner-only decryption)
+6. **Social** (`social.go`, `teasing_test.go`) - Teasing, trends, clout
+7. **Observations** (`observations.go`) - Distributed consensus on network state
 
 ### Event Types (service field)
 
@@ -105,6 +111,7 @@ Individual tests can override with `logrus.SetLevel(logrus.DebugLevel)`.
 - `EVENTS.md` - Event types and structure
 - `OBSERVATIONS.md` - Event-driven consensus system
 - `SYNC.md` - Unified sync backbone and gossip protocol
+- `STASH.md` - Distributed encrypted storage system
 - `WORLD.md` - "Around the world" journey feature
 - `COORDINATES.md` - Vivaldi network coordinate system
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test run run2 clean build-nix
+.PHONY: all build test run run2 clean build-nix test-v test-fast lint-report
 
 # Default target: build and test
 all: build test
@@ -50,3 +50,6 @@ build-nix:
 	@echo "Building nara using Nix..."
 	@nix build .#nara
 	@echo "✓ Built nara using Nix"
+
+lint-report:
+	@golangci-lint run

--- a/STASH.md
+++ b/STASH.md
@@ -1,6 +1,6 @@
 # Stash - Distributed Encrypted Storage
 
-Naras store their encrypted tsnet state on other naras ("confidents") instead of local disk. This enables stateless operation where a nara can reboot on any machine and recover its mesh identity.
+Naras store their encrypted identity data (emojis) on other naras ("confidents") instead of local disk. This enables stateless operation where a nara can reboot on any machine and recover its identity sequence.
 
 ## How It Works
 

--- a/STASH.md
+++ b/STASH.md
@@ -1,0 +1,116 @@
+# Stash - Distributed Encrypted Storage
+
+Naras store their encrypted tsnet state on other naras ("confidents") instead of local disk. This enables stateless operation where a nara can reboot on any machine and recover its mesh identity.
+
+## How It Works
+
+1. **Owner** picks 2-3 random naras as **confidents**
+2. Owner encrypts their tsnet state with their own key (derived from soul)
+3. Owner sends encrypted stash to confidents via DM
+4. Confidents store in **memory only** (lost on restart)
+5. On boot, owner broadcasts "who has my stash?" and recovers from responses
+
+## Key Properties
+
+- **Self-encrypted**: Only the owner can decrypt their stash (key derived from soul)
+- **Random selection**: Confidents are chosen randomly to spread load
+- **Memory-only**: Confidents don't persist stash to disk
+- **Tamper-proof**: Timestamp is inside the encrypted payload
+- **Social reward**: Storing stash for someone gives you clout
+
+## Data Flow
+
+### Storing Stash (Owner -> Confidents)
+
+```
+Owner                           Confident
+  |                                 |
+  |-- StashStore (encrypted) ------>|
+  |                                 | stores in memory
+  |<-------- StashStoreAck ---------|
+```
+
+### Recovering Stash (Boot)
+
+```
+Owner                           All Naras
+  |                                 |
+  |-- StashRequest (broadcast) ---->|
+  |                                 |
+  |<------- StashResponse ----------| (only confidents with stash respond)
+  |                                 |
+  | decrypt, pick newest timestamp  |
+  | write to tsnet state dir        |
+  | start tsnet                     |
+```
+
+### Managing Confidents
+
+- **Target count**: 2-3 confidents
+- **Too few**: Pick random new confident, send StashStore
+- **Too many**: DM extras with StashDelete
+- **Confident offline**: Pick new random confident
+- **Re-send triggers**: Confident reboots, or stash data changes
+
+## MQTT Topics
+
+| Topic | Direction | Message |
+|-------|-----------|---------|
+| `nara/stash/{target}/store` | Owner -> Confident | StashStore |
+| `nara/stash/{owner}/ack` | Confident -> Owner | StashStoreAck |
+| `nara/plaza/stash_request` | Owner -> Broadcast | StashRequest |
+| `nara/stash/{owner}/response` | Confident -> Owner | StashResponse |
+| `nara/stash/{target}/delete` | Owner -> Confident | StashDelete |
+
+## Encryption
+
+Uses XChaCha20-Poly1305 with a symmetric key derived from the owner's Ed25519 private key:
+
+```
+Ed25519 seed -> HKDF("nara:stash:v1") -> 32-byte symmetric key
+```
+
+The encrypted payload contains:
+- `timestamp`: When the stash was created (inside encrypted blob for tamper-proofing)
+- `state`: tar.gz of tsnet state directory (~3KB)
+
+## Security
+
+- **10KB size limit** on stash payload
+- **Signature verification** on StashStore and StashRequest
+- **Path traversal protection** when extracting tar
+- **Memory-only** on confidents (no disk writes)
+- **Random selection** spreads load, avoids "hot keys"
+
+## Boot Sequence
+
+```
+1. MQTT connects
+2. Wait 5s for neighbor discovery
+3. Broadcast StashRequest
+4. Wait up to 2 minutes for StashResponse
+5. If received:
+   - Decrypt all responses
+   - Pick newest by timestamp
+   - Write to tsnet state dir
+   - Start tsnet
+6. If timeout + authkey:
+   - Register fresh with Headscale
+7. If timeout + no authkey:
+   - Mesh disabled
+```
+
+## Social Reward
+
+When a confident stores stash for an owner, they receive clout:
+
+```go
+SocialEvent{
+    Type:   "stash_stored",
+    Actor:  confidentName,
+    Target: ownerName,
+    Reason: ReasonStashStored,
+}
+```
+
+This encourages naras to participate in the stash network.

--- a/STASH.md
+++ b/STASH.md
@@ -1,66 +1,213 @@
 # Stash - Distributed Encrypted Storage
 
-Naras store their encrypted identity data (emojis) on other naras ("confidents") instead of local disk. This enables stateless operation where a nara can reboot on any machine and recover its identity sequence.
+Naras store their encrypted data (arbitrary JSON) on other naras ("confidants") instead of local disk. This enables stateless operation where a nara can reboot on any machine and recover its state.
 
 ## How It Works
 
-1. **Owner** picks 2-3 random naras as **confidents**
-2. Owner encrypts their tsnet state with their own key (derived from soul)
-3. Owner sends encrypted stash to confidents via DM
-4. Confidents store in **memory only** (lost on restart)
-5. On boot, owner broadcasts "who has my stash?" and recovers from responses
+1. **Owner** picks 3 naras as **confidants** (prefers higher memory modes and uptime)
+2. Owner encrypts their arbitrary JSON data with their own key (derived from soul)
+3. Owner sends stash to confidants via `POST /stash/store` over mesh during gossip rounds
+4. Confidants store in **memory only** (never persisted to disk)
+5. On boot, owner's hey-there event triggers confidants to push stash back via `POST /stash/push`
 
 ## Key Properties
 
 - **Self-encrypted**: Only the owner can decrypt their stash (key derived from soul)
-- **Random selection**: Confidents are chosen randomly to spread load
-- **Memory-only**: Confidents don't persist stash to disk
+- **Smart selection**: Confidants chosen by scoring (prefer high memory mode + uptime)
+- **Memory-only**: No disk persistence (sync state lost on restart, re-sync acceptable)
 - **Tamper-proof**: Timestamp is inside the encrypted payload
-- **Social reward**: Storing stash for someone gives you clout
+- **Clear endpoints**: Separate HTTP endpoints for store, retrieve, push, and delete operations
+- **Replay protection**: All requests timestamped and validated (rejects >5min old requests)
+- **Commitment-based**: Confidants accept or reject storage requests based on capacity
+- **Mutual promises**: Both sides track who's storing what (not an anonymous cache)
+- **Memory-aware storage**: Short mode stores 5, Medium 20, Hog 50 stashes for others
+- **Health monitoring**: Owners detect offline confidants and find replacements automatically
+- **Ghost pruning**: Stashes for dead naras (offline 7+ days) are evicted to free capacity
+- **Metrics emission**: Stash storage metrics broadcast in newspaper and logs
+- **Social reward**: Storing stash for someone emits stash_stored social event
+
+## Commitment Model Philosophy
+
+Stash storage is **not an LRU cache** - it's a system of **mutual promises** between naras:
+
+### Why Commitments Matter
+
+**Bad (LRU cache model):**
+- Confidant silently evicts stashes to make room
+- Owner thinks their stash is safe, but it's gone
+- Broken promise, no notification
+- Owner doesn't know they need to find new confidant
+
+**Good (Commitment model):**
+- Confidant accepts or rejects based on capacity
+- If accepted, **promise is kept** until owner dies
+- Owner knows exactly who's storing their stash
+- If confidant goes offline, owner detects it and finds replacement
+
+### The Contract
+
+When a confidant **accepts** a stash:
+1. They track this commitment (not just storage)
+2. They keep it until owner is confirmed dead (offline 7+ days)
+3. They emit a social event (get clout for helping)
+
+When a confidant **rejects** a stash:
+1. Owner knows immediately (HTTP response)
+2. Owner tries another confidant
+3. No broken promises
+
+### Health Monitoring
+
+Both sides actively monitor the relationship:
+- **Owner**: Every 5 min, checks if confidants are still online
+- **Confidant**: Every 5 min, checks if owners are still alive (ghost pruning)
+- **Replacement**: If confidant goes offline, owner automatically finds new one
+
+This creates a **resilient distributed storage network** where promises are kept and failures are handled gracefully.
 
 ## Data Flow
 
-### Storing Stash (Owner -> Confidents)
+### Storing Stash (During Gossip)
 
 ```
-Owner                           Confident
+Owner                           Confidant
   |                                 |
-  |-- StashStore (encrypted) ------>|
-  |                                 | stores in memory
-  |<-------- StashStoreAck ---------|
+  |-- POST /stash/store ----------->| Verify signature & timestamp
+  |    {                            | Check capacity
+  |      From: "owner",             |
+  |      Timestamp: 1234567890,     | If space: Accept commitment ✓
+  |      Stash: <encrypted>,        | If full: Reject (at_capacity) ✗
+  |      Signature: "..."           |
+  |    }                            |
+  |                                 |
+  |<----------- Response -----------|
+  |    {                            |
+  |      Accepted: true/false,      |
+  |      Reason: "..."              | Why rejected (if false)
+  |    }                            |
+  |                                 |
+  | If Accepted:                    | If Accepted:
+  |   Add confidant to tracker      |   Track commitment
+  | If Rejected:                    |   Emit social event
+  |   Try another confidant         |
+  |                                 |
+  | Rate limit: 5 min intervals     |
 ```
 
-### Recovering Stash (Boot)
+**Acceptance/Rejection Reasons:**
+- `accepted` - Commitment created successfully
+- `at_capacity` - No room (already storing max stashes)
+- `stash_too_large` - Payload exceeds size limit (>10KB)
+- `stash_disabled` - Stash storage not enabled
+
+**Timestamp Validation:**
+- Rejects if timestamp >30 seconds old (replay protection)
+- Rejects if timestamp >30s in future (assumes NTP sync)
+
+### Recovering Stash (Boot + Hey-There)
 
 ```
-Owner                           All Naras
+Owner (boots)                   Confidants
   |                                 |
-  |-- StashRequest (broadcast) ---->|
+  |-- hey-there (MQTT) ------------>| (broadcast)
   |                                 |
-  |<------- StashResponse ----------| (only confidents with stash respond)
+  |                                 | Detect: "I have their stash!"
+  |                                 | Wait 2 seconds (let them boot)
   |                                 |
-  | decrypt, pick newest timestamp  |
-  | write to tsnet state dir        |
-  | start tsnet                     |
+  |<-- POST /stash/push ------------| (HTTP push via mesh)
+  |    {                            |
+  |      From: "confidant",         |
+  |      To: "owner",               |
+  |      Timestamp: 1234567890,     |
+  |      Stash: <encrypted>,        |
+  |      Signature: "..."           |
+  |    }                            |
+  |                                 |
+  | Verify signature & timestamp    |
+  | Decrypt, use recovered data     |
+  | Mark confidant in tracker       |
 ```
 
-### Managing Confidents
+**Alternative Recovery (Manual):**
 
-- **Target count**: 2-3 confidents
-- **Too few**: Pick random new confident, send StashStore
-- **Too many**: DM extras with StashDelete
-- **Confident offline**: Pick new random confident
-- **Re-send triggers**: Confident reboots, or stash data changes
+Owner can also explicitly request their stash back:
 
-## MQTT Topics
+```
+Owner                           Confidant
+  |                                 |
+  |-- POST /stash/retrieve -------->| Verify signature & timestamp
+  |    {                            | Check if we have their stash
+  |      From: "owner",             |
+  |      Timestamp: 1234567890,     |
+  |      Signature: "..."           |
+  |    }                            |
+  |                                 |
+  |<----------- Response -----------|
+  |    {                            |
+  |      Found: true/false,         |
+  |      Stash: <encrypted>         | (if found)
+  |    }                            |
+```
 
-| Topic | Direction | Message |
-|-------|-----------|---------|
-| `nara/stash/{target}/store` | Owner -> Confident | StashStore |
-| `nara/stash/{owner}/ack` | Confident -> Owner | StashStoreAck |
-| `nara/plaza/stash_request` | Owner -> Broadcast | StashRequest |
-| `nara/stash/{owner}/response` | Confident -> Owner | StashResponse |
-| `nara/stash/{target}/delete` | Owner -> Confident | StashDelete |
+### Managing Confidants (Commitment Model)
+
+Stash storage is based on **mutual promises** between naras:
+
+**How Commitments Work:**
+1. Owner asks confidant: "Will you store my stash?"
+2. Confidant checks capacity:
+   - If space available: **Accepts** (creates commitment)
+   - If at capacity: **Rejects** with reason
+3. Owner only adds to confirmed confidants if accepted
+4. Confidant tracks commitment and keeps it until owner dies (offline 7+ days)
+
+**Maintenance (runs every 5 minutes):**
+1. **Health Check**: Detect offline/missing confidants, remove from tracker
+2. **Fill Gaps**: If below target (3), pick new confidant and send stash
+3. **Ghost Pruning**: Evict stashes for naras offline >7 days (frees capacity)
+4. **Metrics Logging**: Report storage status
+
+**When Confidant Goes Offline:**
+- Owner detects via OnlineStatusProjection (OFFLINE or MISSING status)
+- Removes from confidant list automatically
+- Next maintenance round finds replacement
+- New confidant receives stash during next gossip exchange
+
+**When Owner Goes Ghost (offline 7+ days):**
+- Confidant's ghost pruning detects prolonged absence
+- Commitment broken - stash evicted
+- Capacity freed for active naras
+
+**Target count**: 3 confidants (configurable)
+**Exchange triggers**: Gossip rounds (every 30-300s), stash data changes, manual recovery
+
+## HTTP Endpoints
+
+### Mesh Endpoints (Nara-to-Nara)
+
+| Endpoint | Method | Auth | Purpose |
+|----------|--------|------|---------|
+| `/stash/store` | POST | Ed25519 mesh auth + timestamp | Owner stores stash with confidant |
+| `/stash/store` | DELETE | Ed25519 mesh auth + timestamp | Owner requests deletion of stash |
+| `/stash/retrieve` | POST | Ed25519 mesh auth + timestamp | Owner retrieves stash from confidant |
+| `/stash/push` | POST | Ed25519 mesh auth + timestamp | Confidant pushes stash to owner (recovery) |
+
+### Web UI Endpoints (Local Only)
+
+| Endpoint | Method | Auth | Purpose |
+|----------|--------|------|---------|
+| `/api/stash/status` | GET | Local only | Get stash + confidants + metrics |
+| `/api/stash/update` | POST | Local only | Update stash data |
+| `/api/stash/recover` | POST | Local only | Trigger manual recovery |
+| `/api/stash/confidants` | GET | Local only | List confidants with details |
+
+**All mesh endpoints:**
+- Require Ed25519 signature in request body
+- Require timestamp (unix seconds) in request body
+- Reject requests >30 seconds old or >30s in future (replay protection, assumes NTP sync)
+- Use mesh authentication headers for transport security
+
+**Note**: MQTT hey-there events still used to trigger automatic recovery (confidants detect boot and push stash via `POST /stash/push`).
 
 ## Encryption
 
@@ -72,45 +219,107 @@ Ed25519 seed -> HKDF("nara:stash:v1") -> 32-byte symmetric key
 
 The encrypted payload contains:
 - `timestamp`: When the stash was created (inside encrypted blob for tamper-proofing)
-- `state`: tar.gz of tsnet state directory (~3KB)
+- `data`: Arbitrary JSON object (freeform user data)
+- `version`: Schema version for future migrations
 
 ## Security
 
-- **10KB size limit** on stash payload
-- **Signature verification** on StashStore and StashRequest
-- **Path traversal protection** when extracting tar
-- **Memory-only** on confidents (no disk writes)
-- **Random selection** spreads load, avoids "hot keys"
+- **Signature verification** on all stash requests (Ed25519, signed with timestamp)
+- **Replay protection** via timestamp validation (rejects >5min old or >60s future)
+- **Memory-only** on confidants (no disk writes, no persistence)
+- **Smart selection** spreads load based on capacity (prefers high memory modes)
+- **Rate limiting** prevents spam (5-minute intervals per peer)
+- **Commitment-based capacity**: Accept/reject based on limits (5/20/50 based on memory mode)
+- **Ghost-only eviction**: Only evict stashes when owner offline 7+ days (keeps promises to living naras)
+- **Encrypted at rest** in memory (only owner can decrypt)
 
 ## Boot Sequence
 
 ```
-1. MQTT connects
-2. Wait 5s for neighbor discovery
-3. Broadcast StashRequest
-4. Wait up to 2 minutes for StashResponse
-5. If received:
+1. MQTT connects (if not gossip-only mode)
+2. Mesh initializes (if authkey present)
+3. Broadcast hey-there event (MQTT + gossip)
+4. Confidants detect hey-there:
+   - Wait 2 seconds (let nara finish booting)
+   - POST /stash/push with their copy of owner's stash
+5. Owner receives stash via push:
    - Decrypt all responses
    - Pick newest by timestamp
-   - Write to tsnet state dir
-   - Start tsnet
-6. If timeout + authkey:
-   - Register fresh with Headscale
-7. If timeout + no authkey:
-   - Mesh disabled
+   - Use recovered data
+6. If no responses after timeout:
+   - Start with empty state (acceptable - ephemeral design)
 ```
+
+**Note**: No explicit broadcast request needed - hey-there event naturally triggers recovery from confidants.
+
+## Metrics Emission
+
+Stash metrics are emitted in two ways:
+
+### Newspaper Broadcasts (NaraStatus)
+```go
+type NaraStatus struct {
+    // ... other fields ...
+    StashStored     int   `json:"stash_stored"`      // # of stashes stored for others
+    StashBytes      int64 `json:"stash_bytes"`       // Total bytes stored
+    StashConfidants int   `json:"stash_confidants"`  // # of confidants storing my stash
+}
+```
+
+### Periodic Logs (every 5 minutes)
+```
+INFO  📦 Stash metrics: stored=15 (1.2MB), my_confidants=3/3, my_size=2.1KB
+```
+
+Metrics help monitor:
+- Storage capacity usage
+- Confidant network health
+- Eviction frequency
+- Overall system load
+
+## Memory-Aware Storage
+
+Confidants store different numbers of stashes based on memory mode:
+
+| Memory Mode | RAM    | Stash Limit | Eviction Policy                    |
+|-------------|--------|-------------|------------------------------------|
+| Short       | 256MB  | 5 stashes   | Accept up to 5, then reject new    |
+| Medium      | 512MB  | 20 stashes  | Accept up to 20, then reject new   |
+| Hog         | 2048MB | 50 stashes  | Accept up to 50, then reject new   |
+
+**Capacity Management:**
+- When limit reached, **new requests are rejected** (not evicted)
+- Existing commitments are **kept until owner goes ghost** (offline 7+ days)
+- Ghost pruning runs every 5 minutes, freeing capacity for active naras
+
+**Confidant Selection**: Owners prefer high-capacity confidants using scoring:
+- Hog mode: +300 points
+- Medium mode: +200 points
+- Short mode: +100 points
+- Uptime (seconds): Added to score
+
+This ensures high-memory naras naturally become "hubs" for stash storage while keeping promises to existing owners.
 
 ## Social Reward
 
-When a confident stores stash for an owner, they receive clout:
+When a confidant stores stash for an owner, a social event is emitted:
 
 ```go
 SocialEvent{
     Type:   "stash_stored",
-    Actor:  confidentName,
+    Actor:  confidantName,
     Target: ownerName,
     Reason: ReasonStashStored,
 }
 ```
 
-This encourages naras to participate in the stash network.
+This encourages naras to participate in the stash network and rewards high-uptime, high-capacity nodes.
+
+## Web UI
+
+Access stash management at `/stash.html`:
+- **JSON Editor**: Edit arbitrary stash data with syntax highlighting
+- **Confidant Status**: View who's storing your stash
+- **Metrics Dashboard**: See storage usage and health
+- **Manual Recovery**: Trigger immediate recovery
+- **Storage Info**: View how many stashes you're storing for others

--- a/SYNC.md
+++ b/SYNC.md
@@ -45,7 +45,9 @@ These events use **importance levels** (1-3) and have anti-abuse protection (per
 ### Social Events (`service: "social"`)
 Social interactions between naras:
 - **tease**: One nara teasing another (for high restarts, comebacks, etc.)
+- **observed**: One nara reporting a tease they saw elsewhere
 - **observation**: Legacy system observations (online/offline, journey events)
+- **service**: Helpful actions (like `stash-stored`) that award clout to the actor
 - **gossip**: Hearsay about what happened
 
 ### Ping Observations (`service: "ping"`)
@@ -174,13 +176,13 @@ These survive in the distributed event log and spread via zine gossip:
 
 | Service | Key Data | Purpose |
 |---------|----------|---------|
-| `hey-there` | PublicKey, MeshIP | Identity/discovery |
-| `chau` | From, PublicKey | Graceful shutdown signal |
+| `chau` | From, PublicKey | Identity/discovery |
 | `observation` | StartTime, RestartNum, LastRestart, OnlineState | Network state consensus |
 | `ping` | Observer, Target, RTT | Latency measurements |
-| `social` | Actor, Target, Reason | Teases and interactions |
+| `social` | Actor, Target, Reason | Teases, helpful services, and interactions |
 | `seen` | Observer, Subject, Via | Lightweight presence detection |
 
+### Implications
 Events are **state transitions** - they record what happened, not current state.
 
 ### Implications

--- a/crypto.go
+++ b/crypto.go
@@ -2,10 +2,15 @@ package nara
 
 import (
 	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"io"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/hkdf"
 )
 
 // NaraKeypair holds an Ed25519 keypair derived from a soul
@@ -78,4 +83,71 @@ func VerifySignatureBase64(publicKey []byte, message []byte, signatureBase64 str
 		return false
 	}
 	return VerifySignature(publicKey, message, signature)
+}
+
+// EncryptionKeypair holds a symmetric key derived from an Ed25519 private key
+// Used for self-encryption (encrypt data that only the owner can decrypt)
+type EncryptionKeypair struct {
+	SymmetricKey []byte // 32-byte key for XChaCha20-Poly1305
+}
+
+// DeriveEncryptionKeys derives a symmetric encryption key from an Ed25519 private key
+// Uses HKDF with SHA-256 to derive a 32-byte key for XChaCha20-Poly1305
+func DeriveEncryptionKeys(privateKey ed25519.PrivateKey) EncryptionKeypair {
+	// Extract the seed from the private key (first 32 bytes)
+	seed := privateKey.Seed()
+
+	// Use HKDF to derive the encryption key
+	// Salt: "nara:stash:v1" (domain separation)
+	// Info: "symmetric" (key purpose)
+	hkdfReader := hkdf.New(sha256.New, seed, []byte("nara:stash:v1"), []byte("symmetric"))
+
+	symmetricKey := make([]byte, 32)
+	if _, err := io.ReadFull(hkdfReader, symmetricKey); err != nil {
+		// This should never happen with HKDF
+		panic("hkdf failed: " + err.Error())
+	}
+
+	return EncryptionKeypair{
+		SymmetricKey: symmetricKey,
+	}
+}
+
+// EncryptForSelf encrypts plaintext using XChaCha20-Poly1305 with a random nonce
+// Returns the nonce and ciphertext separately so the nonce can be stored with the payload
+func (kp EncryptionKeypair) EncryptForSelf(plaintext []byte) (nonce, ciphertext []byte, err error) {
+	aead, err := chacha20poly1305.NewX(kp.SymmetricKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Generate random nonce (24 bytes for XChaCha20)
+	nonce = make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, nil, err
+	}
+
+	// Encrypt (ciphertext includes auth tag)
+	ciphertext = aead.Seal(nil, nonce, plaintext, nil)
+
+	return nonce, ciphertext, nil
+}
+
+// DecryptForSelf decrypts ciphertext using XChaCha20-Poly1305
+func (kp EncryptionKeypair) DecryptForSelf(nonce, ciphertext []byte) ([]byte, error) {
+	aead, err := chacha20poly1305.NewX(kp.SymmetricKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(nonce) != aead.NonceSize() {
+		return nil, errors.New("invalid nonce size")
+	}
+
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, errors.New("decryption failed: invalid ciphertext or wrong key")
+	}
+
+	return plaintext, nil
 }

--- a/http.go
+++ b/http.go
@@ -1268,10 +1268,10 @@ func (network *Network) httpStashPushHandler(w http.ResponseWriter, r *http.Requ
 // GET /api/stash/status - Get current stash status, confidants, and metrics
 func (network *Network) httpStashStatusHandler(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
-		"has_stash": false,
-		"my_stash":  nil,
+		"has_stash":  false,
+		"my_stash":   nil,
 		"confidants": []map[string]interface{}{},
-		"metrics":   map[string]interface{}{},
+		"metrics":    map[string]interface{}{},
 	}
 
 	// Get my current stash data
@@ -1306,10 +1306,10 @@ func (network *Network) httpStashStatusHandler(w http.ResponseWriter, r *http.Re
 	if network.confidantStore != nil {
 		metrics := network.confidantStore.GetMetrics()
 		response["metrics"] = map[string]interface{}{
-			"stashes_stored":   metrics.StashesStored,
-			"total_bytes":      metrics.TotalStashBytes,
-			"eviction_count":   metrics.EvictionCount,
-			"storage_limit":    network.confidantStore.maxStashes,
+			"stashes_stored": metrics.StashesStored,
+			"total_bytes":    metrics.TotalStashBytes,
+			"eviction_count": metrics.EvictionCount,
+			"storage_limit":  network.confidantStore.maxStashes,
 		}
 	}
 

--- a/integration_stash_http_test.go
+++ b/integration_stash_http_test.go
@@ -1,0 +1,278 @@
+package nara
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// TestStashHTTPExchange_EndToEnd tests the full HTTP-based stash flow:
+// 1. Owner creates stash and distributes to confidant
+// 2. Confidant accepts and stores the stash
+// 3. Owner "restarts" (loses local stash)
+// 4. Owner recovers stash from confidant via HTTP
+func TestStashHTTPExchange_EndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Enable debug logs to troubleshoot
+	logrus.SetLevel(logrus.DebugLevel)
+	defer logrus.SetLevel(logrus.InfoLevel)
+
+	// Start embedded MQTT broker on unique port
+	broker := startTestMQTTBroker(t, 11885)
+	defer broker.Close()
+	time.Sleep(200 * time.Millisecond) // Let broker start
+
+	// Create owner and confidant naras with MQTT broker
+	ownerIdentity := testIdentity("owner")
+	owner, _ := NewLocalNara(ownerIdentity, "localhost:11885", "", "", 50, DefaultMemoryProfile())
+	owner.Network.confidantStore.SetMaxStashes(10)
+	owner.Network.stashManager = NewStashManager("owner", owner.Keypair, 2)
+
+	confidantIdentity := testIdentity("confidant")
+	confidant, _ := NewLocalNara(confidantIdentity, "localhost:11885", "", "", 50, DefaultMemoryProfile())
+	confidant.Network.confidantStore.SetMaxStashes(10)
+	confidant.Network.stashManager = NewStashManager("confidant", confidant.Keypair, 2)
+
+	// Connect both to MQTT manually (they would normally connect during Start())
+	if token := owner.Network.Mqtt.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Owner MQTT connection failed: %v", token.Error())
+	}
+	if token := confidant.Network.Mqtt.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Confidant MQTT connection failed: %v", token.Error())
+	}
+	defer owner.Network.disconnectMQTT()
+	defer confidant.Network.disconnectMQTT()
+	time.Sleep(100 * time.Millisecond) // Let MQTT connections establish
+
+	// Start HTTP servers for both
+	ownerMux := http.NewServeMux()
+	ownerMux.HandleFunc("/stash/store", owner.Network.httpStashHandler)
+	ownerMux.HandleFunc("/stash/retrieve", owner.Network.httpStashRetrieveHandler)
+	ownerMux.HandleFunc("/stash/push", owner.Network.httpStashPushHandler)
+	ownerHTTP := httptest.NewServer(ownerMux)
+	defer ownerHTTP.Close()
+
+	confidantMux := http.NewServeMux()
+	confidantMux.HandleFunc("/stash/store", confidant.Network.httpStashHandler)
+	confidantMux.HandleFunc("/stash/retrieve", confidant.Network.httpStashRetrieveHandler)
+	confidantMux.HandleFunc("/stash/push", confidant.Network.httpStashPushHandler)
+	confidantHTTP := httptest.NewServer(confidantMux)
+	defer confidantHTTP.Close()
+
+	// Set up test URLs and HTTP client
+	sharedClient := &http.Client{Timeout: 5 * time.Second}
+	owner.Network.testHTTPClient = sharedClient
+	owner.Network.testMeshURLs = map[string]string{"confidant": confidantHTTP.URL}
+	confidant.Network.testHTTPClient = sharedClient
+	confidant.Network.testMeshURLs = map[string]string{"owner": ownerHTTP.URL}
+
+	// Set up identities so they can verify each other's signatures
+	ownerNara := NewNara("owner")
+	ownerNara.Status.PublicKey = FormatPublicKey(owner.Keypair.PublicKey)
+	confidant.Network.importNara(ownerNara)
+
+	confidantNara := NewNara("confidant")
+	confidantNara.Status.PublicKey = FormatPublicKey(confidant.Keypair.PublicKey)
+	owner.Network.importNara(confidantNara)
+
+	// STEP 1: Owner creates stash data
+	originalData := map[string]interface{}{
+		"notes": "My secret data",
+		"preferences": map[string]interface{}{
+			"theme": "dark",
+			"notifications": true,
+		},
+		"numbers": []int{1, 2, 3, 4, 5},
+	}
+	originalDataJSON, err := json.Marshal(originalData)
+	if err != nil {
+		t.Fatalf("Failed to marshal original data: %v", err)
+	}
+
+	// Set current stash on owner
+	owner.Network.stashManager.SetCurrentStash(originalDataJSON)
+
+	// STEP 2: Owner exchanges stash with confidant
+	owner.Network.exchangeStashWithPeer("confidant")
+
+	// Give it a moment to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// STEP 3: Verify confidant has stored the stash
+	if !confidant.Network.confidantStore.HasStashFor("owner") {
+		t.Fatal("Confidant should have stored owner's stash")
+	}
+
+	// Verify owner marked confidant as confirmed
+	if !owner.Network.stashManager.confidantTracker.Has("confidant") {
+		t.Fatal("Owner should have marked confidant as confirmed")
+	}
+
+	metrics := confidant.Network.confidantStore.GetMetrics()
+	if metrics.StashesStored != 1 {
+		t.Errorf("Expected confidant to store 1 stash, got %d", metrics.StashesStored)
+	}
+
+	// STEP 4: Simulate owner restart - loses local stash
+	owner.Network.stashManager = NewStashManager("owner", owner.Keypair, 2)
+	if owner.Network.stashManager.HasStashData() {
+		t.Fatal("Owner should not have stash data after restart")
+	}
+
+	// STEP 5: Owner sends hey-there (simulating boot), confidant sees it and pushes stash back
+	pubKeyStr := FormatPublicKey(owner.Keypair.PublicKey)
+	heyThereEvent := NewHeyThereSyncEvent("owner", pubKeyStr, "", owner.ID, owner.Keypair)
+
+	// Publish hey-there via MQTT
+	topic := "nara/plaza/hey_there"
+	owner.Network.postEvent(topic, heyThereEvent)
+
+	// Wait for confidant to process hey-there and push stash back via HTTP
+	time.Sleep(3 * time.Second) // Give time for hey-there handler to trigger HTTP push
+
+	// STEP 6: Verify owner recovered stash
+	if !owner.Network.stashManager.HasStashData() {
+		t.Fatal("Owner should have recovered stash data")
+	}
+
+	recoveredStash := owner.Network.stashManager.GetCurrentStash()
+	if recoveredStash == nil {
+		t.Fatal("Recovered stash should not be nil")
+	}
+
+	// STEP 7: Verify recovered data matches original
+	var recoveredData map[string]interface{}
+	if err := json.Unmarshal(recoveredStash.Data, &recoveredData); err != nil {
+		t.Fatalf("Failed to unmarshal recovered data: %v", err)
+	}
+
+	// Check notes field
+	if notes, ok := recoveredData["notes"].(string); !ok || notes != "My secret data" {
+		t.Errorf("Expected notes='My secret data', got %v", recoveredData["notes"])
+	}
+
+	// Check preferences
+	if prefs, ok := recoveredData["preferences"].(map[string]interface{}); ok {
+		if theme, ok := prefs["theme"].(string); !ok || theme != "dark" {
+			t.Errorf("Expected theme='dark', got %v", prefs["theme"])
+		}
+		if notif, ok := prefs["notifications"].(bool); !ok || !notif {
+			t.Errorf("Expected notifications=true, got %v", prefs["notifications"])
+		}
+	} else {
+		t.Error("Expected preferences object")
+	}
+
+	// Verify confidant is still marked as confirmed
+	if !owner.Network.stashManager.confidantTracker.Has("confidant") {
+		t.Error("Owner should still have confidant marked after recovery")
+	}
+
+	t.Logf("✓ End-to-end stash exchange successful: %d bytes stored and recovered",
+		len(recoveredStash.Data))
+}
+
+// TestStashHTTPExchange_Rejection tests stash rejection when confidant is at capacity
+func TestStashHTTPExchange_Rejection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	logrus.SetLevel(logrus.WarnLevel)
+	defer logrus.SetLevel(logrus.InfoLevel)
+
+	// Start MQTT broker
+	broker := startTestMQTTBroker(t, 11886)
+	defer broker.Close()
+	time.Sleep(200 * time.Millisecond)
+
+	// Create owner and confidant
+	ownerIdentity := testIdentity("owner")
+	owner, _ := NewLocalNara(ownerIdentity, "localhost:11886", "", "", 50, DefaultMemoryProfile())
+	owner.Network.confidantStore.SetMaxStashes(5)
+	owner.Network.stashManager = NewStashManager("owner", owner.Keypair, 2)
+
+	confidantIdentity := testIdentity("confidant")
+	confidant, _ := NewLocalNara(confidantIdentity, "localhost:11886", "", "", 50, DefaultMemoryProfile())
+	confidant.Network.confidantStore.SetMaxStashes(1) // Only 1 stash!
+	confidant.Network.stashManager = NewStashManager("confidant", confidant.Keypair, 2)
+
+	if token := owner.Network.Mqtt.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Owner MQTT connection failed: %v", token.Error())
+	}
+	if token := confidant.Network.Mqtt.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Confidant MQTT connection failed: %v", token.Error())
+	}
+	defer owner.Network.disconnectMQTT()
+	defer confidant.Network.disconnectMQTT()
+	time.Sleep(100 * time.Millisecond)
+
+	// Start HTTP servers
+	ownerMux := http.NewServeMux()
+	ownerMux.HandleFunc("/stash/store", owner.Network.httpStashHandler)
+	ownerMux.HandleFunc("/stash/retrieve", owner.Network.httpStashRetrieveHandler)
+	ownerMux.HandleFunc("/stash/push", owner.Network.httpStashPushHandler)
+	ownerHTTP := httptest.NewServer(ownerMux)
+	defer ownerHTTP.Close()
+
+	confidantMux := http.NewServeMux()
+	confidantMux.HandleFunc("/stash/store", confidant.Network.httpStashHandler)
+	confidantMux.HandleFunc("/stash/retrieve", confidant.Network.httpStashRetrieveHandler)
+	confidantMux.HandleFunc("/stash/push", confidant.Network.httpStashPushHandler)
+	confidantHTTP := httptest.NewServer(confidantMux)
+	defer confidantHTTP.Close()
+
+	sharedClient := &http.Client{Timeout: 5 * time.Second}
+	owner.Network.testHTTPClient = sharedClient
+	owner.Network.testMeshURLs = map[string]string{"confidant": confidantHTTP.URL}
+	confidant.Network.testHTTPClient = sharedClient
+	confidant.Network.testMeshURLs = map[string]string{"owner": ownerHTTP.URL}
+
+	ownerNara := NewNara("owner")
+	ownerNara.Status.PublicKey = FormatPublicKey(owner.Keypair.PublicKey)
+	confidant.Network.importNara(ownerNara)
+
+	confidantNara := NewNara("confidant")
+	confidantNara.Status.PublicKey = FormatPublicKey(confidant.Keypair.PublicKey)
+	owner.Network.importNara(confidantNara)
+
+	// Fill confidant's capacity with someone else's stash first
+	dummyNara := testLocalNara("dummy")
+	dummyData := testStashData(time.Now().Unix(), []string{"🎲"})
+	dummyKeypair := DeriveEncryptionKeys(dummyNara.Keypair.PrivateKey)
+	dummyPayload, _ := CreateStashPayload("dummy", dummyData, dummyKeypair)
+	confidant.Network.confidantStore.Store("dummy", dummyPayload)
+
+	// Verify confidant is at capacity
+	metrics := confidant.Network.confidantStore.GetMetrics()
+	if metrics.StashesStored != 1 {
+		t.Fatalf("Expected 1 stash stored, got %d", metrics.StashesStored)
+	}
+
+	// Now owner tries to store stash
+	ownerData := map[string]interface{}{"test": "data"}
+	ownerDataJSON, _ := json.Marshal(ownerData)
+	owner.Network.stashManager.SetCurrentStash(ownerDataJSON)
+
+	owner.Network.exchangeStashWithPeer("confidant")
+	time.Sleep(100 * time.Millisecond)
+
+	// Confidant should have rejected (at capacity)
+	if confidant.Network.confidantStore.HasStashFor("owner") {
+		t.Error("Confidant should have rejected owner's stash (at capacity)")
+	}
+
+	// Owner should NOT have confidant marked as confirmed
+	if owner.Network.stashManager.confidantTracker.Has("confidant") {
+		t.Error("Owner should not mark confidant as confirmed after rejection")
+	}
+
+	t.Log("✓ Stash rejection works correctly when at capacity")
+}

--- a/integration_stash_http_test.go
+++ b/integration_stash_http_test.go
@@ -86,7 +86,7 @@ func TestStashHTTPExchange_EndToEnd(t *testing.T) {
 	originalData := map[string]interface{}{
 		"notes": "My secret data",
 		"preferences": map[string]interface{}{
-			"theme": "dark",
+			"theme":         "dark",
 			"notifications": true,
 		},
 		"numbers": []int{1, 2, 3, 4, 5},

--- a/nara-web/public/index.html
+++ b/nara-web/public/index.html
@@ -290,6 +290,7 @@
       <div style="font-weight:600;">nara</div>
       <div style="display:flex; gap:14px; font-size:14px;">
         <a href="/resources.html">resource usage</a>
+        <a href="/stash.html">stash</a>
       </div>
     </div>
     <div id="naras_container"></div>

--- a/nara-web/public/nara.js
+++ b/nara-web/public/nara.js
@@ -499,11 +499,6 @@ function NaraList() {
 
   return (
     <div>
-      <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px'}}>
-        <a href="/stash.html" style={{padding: '8px 16px', background: '#007bff', color: 'white', borderRadius: '4px', textDecoration: 'none', fontSize: '14px'}}>
-          📦 Stash Manager
-        </a>
-      </div>
       <TrendSummary naras={data.filteredNaras} />
       <table id="naras">
         <thead>

--- a/nara-web/public/nara.js
+++ b/nara-web/public/nara.js
@@ -499,6 +499,11 @@ function NaraList() {
 
   return (
     <div>
+      <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px'}}>
+        <a href="/stash.html" style={{padding: '8px 16px', background: '#007bff', color: 'white', borderRadius: '4px', textDecoration: 'none', fontSize: '14px'}}>
+          📦 Stash Manager
+        </a>
+      </div>
       <TrendSummary naras={data.filteredNaras} />
       <table id="naras">
         <thead>

--- a/nara-web/public/stash.html
+++ b/nara-web/public/stash.html
@@ -10,9 +10,11 @@
     <style>
     body {
       font-family: Helvetica Neue;
-      margin: 20px;
+      margin: 0;
       background: #f5f5f5;
     }
+    a { text-decoration: none; color: black; }
+    a:hover { text-decoration: underline; color: #007bff; }
     .container {
       max-width: 1200px;
       margin: 0 auto;
@@ -153,7 +155,15 @@
     </style>
   </head>
   <body>
-    <div id="stash_container"></div>
+    <div style="display:flex; align-items:center; justify-content:space-between; padding:12px 16px; border-bottom:1px solid #eee; font-family: Helvetica Neue; background: white;">
+      <div style="font-weight:600;">nara</div>
+      <div style="display:flex; gap:14px; font-size:14px;">
+        <a href="/">home</a>
+        <a href="/resources.html">resource usage</a>
+        <a href="/stash.html">stash</a>
+      </div>
+    </div>
+    <div id="stash_container" style="margin-top: 20px;"></div>
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
     <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>

--- a/nara-web/public/stash.html
+++ b/nara-web/public/stash.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>nara - stash</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsoneditor@9.10.0/dist/jsoneditor.min.css" />
+    <script src="https://cdn.jsdelivr.net/npm/jsoneditor@9.10.0/dist/jsoneditor.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.11.10/dayjs.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.11.10/plugin/relativeTime.min.js" crossorigin="anonymous"></script>
+    <style>
+    body {
+      font-family: Helvetica Neue;
+      margin: 20px;
+      background: #f5f5f5;
+    }
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 20px;
+      padding: 20px;
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    .header h1 {
+      margin: 0;
+      font-size: 24px;
+    }
+    .header a {
+      color: #007bff;
+      text-decoration: none;
+    }
+    .header a:hover {
+      text-decoration: underline;
+    }
+    .card {
+      background: white;
+      padding: 20px;
+      margin-bottom: 20px;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    .card h2 {
+      margin: 0 0 15px 0;
+      font-size: 18px;
+      color: #333;
+    }
+    .status-row {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 10px;
+      padding: 10px;
+      background: #f9f9f9;
+      border-radius: 4px;
+    }
+    .status-label {
+      font-weight: bold;
+      color: #666;
+    }
+    .status-value {
+      color: #333;
+    }
+    .editor-container {
+      height: 400px;
+      margin-bottom: 15px;
+    }
+    .button {
+      background: #007bff;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 4px;
+      cursor: pointer;
+      margin-right: 10px;
+      font-size: 14px;
+    }
+    .button:hover {
+      background: #0056b3;
+    }
+    .button:disabled {
+      background: #ccc;
+      cursor: not-allowed;
+    }
+    .button.secondary {
+      background: #6c757d;
+    }
+    .button.secondary:hover {
+      background: #5a6268;
+    }
+    .confidant-list {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 10px;
+    }
+    .confidant-item {
+      padding: 10px;
+      background: #f9f9f9;
+      border-radius: 4px;
+      border-left: 3px solid #28a745;
+    }
+    .confidant-name {
+      font-weight: bold;
+      margin-bottom: 5px;
+    }
+    .confidant-detail {
+      font-size: 12px;
+      color: #666;
+    }
+    .metrics-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 15px;
+    }
+    .metric-box {
+      padding: 15px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      border-radius: 8px;
+      text-align: center;
+    }
+    .metric-value {
+      font-size: 32px;
+      font-weight: bold;
+      margin-bottom: 5px;
+    }
+    .metric-label {
+      font-size: 14px;
+      opacity: 0.9;
+    }
+    .message {
+      padding: 10px;
+      margin-top: 10px;
+      border-radius: 4px;
+      display: none;
+    }
+    .message.success {
+      background: #d4edda;
+      color: #155724;
+      border: 1px solid #c3e6cb;
+      display: block;
+    }
+    .message.error {
+      background: #f8d7da;
+      color: #721c24;
+      border: 1px solid #f5c6cb;
+      display: block;
+    }
+    </style>
+  </head>
+  <body>
+    <div id="stash_container"></div>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+    <script src="stash.js" type="text/babel"></script>
+  </body>
+</html>

--- a/nara-web/public/stash.js
+++ b/nara-web/public/stash.js
@@ -1,0 +1,266 @@
+const { useState, useEffect, useRef } = React;
+
+function StashManager() {
+  const [status, setStatus] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState({ text: '', type: '' });
+  const editorRef = useRef(null);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    fetchStatus();
+    const interval = setInterval(fetchStatus, 5000); // Refresh every 5 seconds
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (containerRef.current && !editorRef.current && status) {
+      // Initialize JSONEditor
+      const options = {
+        mode: 'tree',
+        modes: ['tree', 'code', 'form', 'text', 'view'],
+        onChangeText: () => {
+          // Editor content changed
+        }
+      };
+      editorRef.current = new JSONEditor(containerRef.current, options);
+
+      // Use existing stash data, or provide sample placeholder
+      let initialData = {};
+      if (status.my_stash && status.my_stash.data) {
+        initialData = status.my_stash.data;
+      } else {
+        // Sample placeholder data
+        initialData = {
+          notes: "My personal notes",
+          preferences: {
+            theme: "dark",
+            notifications: true
+          },
+          bookmarks: [
+            "https://example.com",
+            "https://github.com"
+          ]
+        };
+      }
+
+      editorRef.current.set(initialData);
+    }
+  }, [status]);
+
+  async function fetchStatus() {
+    try {
+      const response = await fetch('/api/stash/status');
+      const data = await response.json();
+      setStatus(data);
+      setLoading(false);
+
+      // Update editor if it exists
+      if (editorRef.current && data.my_stash) {
+        editorRef.current.update(data.my_stash.data || {});
+      }
+    } catch (error) {
+      console.error('Failed to fetch status:', error);
+      setLoading(false);
+    }
+  }
+
+  async function handleUpdate() {
+    if (!editorRef.current) return;
+
+    try {
+      const data = editorRef.current.get();
+      const response = await fetch('/api/stash/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+
+      const result = await response.json();
+      showMessage(result.message || 'Stash updated successfully', 'success');
+      setTimeout(fetchStatus, 1000);
+    } catch (error) {
+      showMessage('Failed to update stash: ' + error.message, 'error');
+    }
+  }
+
+  async function handleRecover() {
+    try {
+      const response = await fetch('/api/stash/recover', {
+        method: 'POST'
+      });
+
+      const result = await response.json();
+      showMessage(result.message || 'Recovery initiated', 'success');
+      setTimeout(fetchStatus, 2000);
+    } catch (error) {
+      showMessage('Failed to initiate recovery: ' + error.message, 'error');
+    }
+  }
+
+  function handleClear() {
+    if (editorRef.current && confirm('Clear all stash data?')) {
+      editorRef.current.set({});
+    }
+  }
+
+  function showMessage(text, type) {
+    setMessage({ text, type });
+    setTimeout(() => setMessage({ text: '', type: '' }), 5000);
+  }
+
+  function formatBytes(bytes) {
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return (bytes / Math.pow(k, i)).toFixed(2) + ' ' + sizes[i];
+  }
+
+  function formatTimestamp(ts) {
+    if (!ts) return 'Never';
+    dayjs.extend(dayjs_plugin_relativeTime);
+    return dayjs.unix(ts).fromNow();
+  }
+
+  if (loading) {
+    return (
+      <div className="container">
+        <div className="header">
+          <h1>📦 Stash Manager</h1>
+          <a href="/">← Back to Naras</a>
+        </div>
+        <div className="card">
+          <p>Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const metrics = (status && status.metrics) || {};
+  const myStash = status && status.my_stash;
+  const confidants = (status && status.confidants) || [];
+  const targetCount = (status && status.target_count) || 2;
+
+  return (
+    <div className="container">
+      <div className="header">
+        <h1>📦 Stash Manager</h1>
+        <a href="/">← Back to Naras</a>
+      </div>
+
+      {/* Metrics Overview */}
+      <div className="card">
+        <h2>📊 Metrics</h2>
+        <div className="metrics-grid">
+          <div className="metric-box">
+            <div className="metric-value">{metrics.stashes_stored || 0}</div>
+            <div className="metric-label">Stashes Stored</div>
+          </div>
+          <div className="metric-box">
+            <div className="metric-value">{formatBytes(metrics.total_bytes || 0)}</div>
+            <div className="metric-label">Total Size</div>
+          </div>
+          <div className="metric-box">
+            <div className="metric-value">{confidants.length}/{targetCount}</div>
+            <div className="metric-label">Confidants</div>
+          </div>
+          <div className="metric-box">
+            <div className="metric-value">{metrics.storage_limit || 0}</div>
+            <div className="metric-label">Storage Limit</div>
+          </div>
+        </div>
+      </div>
+
+      {/* My Stash Status */}
+      <div className="card">
+        <h2>💾 My Stash</h2>
+        {myStash ? (
+          <div>
+            <div className="status-row">
+              <span className="status-label">Last Updated:</span>
+              <span className="status-value">{formatTimestamp(myStash.timestamp)}</span>
+            </div>
+            <div className="status-row">
+              <span className="status-label">Confidants:</span>
+              <span className="status-value">
+                {confidants.length} / {targetCount}
+                {confidants.length >= targetCount ? ' ✅' : ' ⚠️'}
+              </span>
+            </div>
+          </div>
+        ) : (
+          <p style={{color: '#666'}}>No stash data yet. Create one below!</p>
+        )}
+      </div>
+
+      {/* JSON Editor */}
+      <div className="card">
+        <h2>✏️ Edit Stash Data</h2>
+        <div className="editor-container" ref={containerRef}></div>
+        <div style={{marginTop: '10px'}}>
+          <button className="button" onClick={handleUpdate}>
+            💾 Save & Distribute
+          </button>
+          <button className="button secondary" onClick={handleClear}>
+            🗑️ Clear
+          </button>
+          <button className="button secondary" onClick={handleRecover}>
+            🔄 Trigger Recovery
+          </button>
+        </div>
+        {message.text && (
+          <div className={`message ${message.type}`}>
+            {message.text}
+          </div>
+        )}
+      </div>
+
+      {/* Confidants List */}
+      <div className="card">
+        <h2>🤝 Confidants ({confidants.length})</h2>
+        {confidants.length > 0 ? (
+          <div className="confidant-list">
+            {confidants.map((c, i) => (
+              <div key={i} className="confidant-item">
+                <div className="confidant-name">{c.name}</div>
+                <div className="confidant-detail">
+                  {c.memory_mode ? `Memory: ${c.memory_mode}` : 'Status: confirmed'}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p style={{color: '#666'}}>
+            No confidants yet. They'll be selected automatically once you have stash data.
+          </p>
+        )}
+      </div>
+
+      {/* Storage Metrics */}
+      <div className="card">
+        <h2>💽 Storage (for others)</h2>
+        <div className="status-row">
+          <span className="status-label">Stashes Stored:</span>
+          <span className="status-value">{metrics.stashes_stored || 0}</span>
+        </div>
+        <div className="status-row">
+          <span className="status-label">Total Size:</span>
+          <span className="status-value">{formatBytes(metrics.total_bytes || 0)}</span>
+        </div>
+        <div className="status-row">
+          <span className="status-label">Storage Limit:</span>
+          <span className="status-value">{metrics.storage_limit || 0} stashes</span>
+        </div>
+        <div className="status-row">
+          <span className="status-label">Ghost Prunings:</span>
+          <span className="status-value" title="Stashes removed when owner offline 7+ days">
+            {metrics.eviction_count || 0}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.render(<StashManager />, document.getElementById('stash_container'));

--- a/nara.go
+++ b/nara.go
@@ -72,6 +72,9 @@ type NaraStatus struct {
 	MemoryMode          string             `json:"memory_mode,omitempty"`
 	MemoryBudgetMB      int                `json:"memory_budget_mb,omitempty"`
 	MemoryMaxEvents     int                `json:"memory_max_events,omitempty"`
+	StashStored         int                `json:"stash_stored,omitempty"`     // Number of stashes stored for others
+	StashBytes          int64              `json:"stash_bytes,omitempty"`      // Total bytes of stash data stored
+	StashConfidants     int                `json:"stash_confidants,omitempty"` // Number of confidants storing my stash
 	// remember to sync with setValuesFrom
 	// NOTE: Soul was removed - NEVER serialize private keys!
 }

--- a/network.go
+++ b/network.go
@@ -1243,15 +1243,6 @@ func (network *Network) Start(serveUI bool, httpAddr string, meshConfig *TsnetCo
 	// Store mesh config for stash recovery
 	network.meshConfig = meshConfig
 
-	// Only connect to MQTT if not in gossip-only mode
-	if network.TransportMode != TransportGossip {
-		if token := network.Mqtt.Connect(); token.Wait() && token.Error() != nil {
-			logrus.Fatalf("MQTT connection error: %v", token.Error())
-		}
-	} else {
-		logrus.Info("📡 Gossip-only mode: MQTT disabled")
-	}
-
 	// Start stash processing goroutines
 	go network.processStashStoreRequests()
 	go network.processStashAcks()

--- a/network.go
+++ b/network.go
@@ -4475,14 +4475,25 @@ func (network *Network) handleStashStore(msg StashStore) {
 
 	// Record social event: we're helping them!
 	if network.local.SyncLedger != nil {
-		event := SocialEvent{
-			Timestamp: time.Now().Unix(),
-			Type:      "service",
-			Actor:     network.meName(),
-			Target:    msg.From,
-			Reason:    ReasonStashStored,
+		event := SocialEventPayload{
+			Type:    "service",
+			Actor:   network.meName(),
+			Target:  msg.From,
+			Reason:  ReasonStashStored,
+			Witness: network.meName(),
 		}
-		network.local.SyncLedger.AddSocialEventFilteredLegacy(event, network.local.Me.Status.Personality)
+
+		// Create SyncEvent
+		syncEvent := SyncEvent{
+			Service:   ServiceSocial,
+			Timestamp: time.Now().UnixNano(),
+			Emitter:   network.meName(),
+			Social:    &event,
+		}
+		syncEvent.ComputeID()
+
+		// Add personality filtered event
+		network.local.SyncLedger.AddSocialEventFiltered(syncEvent, network.local.Me.Status.Personality)
 	}
 }
 

--- a/network_context.go
+++ b/network_context.go
@@ -1,0 +1,136 @@
+package nara
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+// HTTPClient is a minimal interface for HTTP operations (allows mocking in tests)
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// NetworkContext provides a clean interface for services to access Network functionality
+// without tight coupling. Services should depend on this interface (or an extension of it)
+// rather than directly on *Network.
+//
+// This enables:
+// - Easier testing (mock the interface)
+// - Clear dependency boundaries
+// - Reduced coupling between components
+type NetworkContext interface {
+	// Identity
+	MyName() string
+	Keypair() NaraKeypair
+
+	// Mesh HTTP operations
+	BuildMeshURL(name string, path string) string
+	GetMeshHTTPClient() HTTPClient
+	AddMeshAuthHeaders(req *http.Request)
+	HasMeshConnectivity(name string) bool
+
+	// Peer information
+	GetOnlineMeshPeers() []string
+	GetPeerInfo(names []string) []PeerInfo
+	GetOnlineStatus(name string) *OnlineState
+
+	// State
+	IsReadOnly() bool
+	IsBooting() bool
+	EnsureProjectionsUpdated()
+
+	// Lifecycle
+	Context() context.Context
+}
+
+// networkContext adapts Network to implement the NetworkContext interface.
+// This is the canonical adapter that services should use.
+type networkContext struct {
+	network *Network
+}
+
+// NewNetworkContext creates a NetworkContext adapter for the given Network.
+// This can be used by any service that needs access to network functionality.
+func (network *Network) NewNetworkContext() NetworkContext {
+	return &networkContext{network: network}
+}
+
+func (c *networkContext) MyName() string {
+	return c.network.meName()
+}
+
+func (c *networkContext) Keypair() NaraKeypair {
+	return c.network.local.Keypair
+}
+
+func (c *networkContext) BuildMeshURL(name string, path string) string {
+	return c.network.buildMeshURL(name, path)
+}
+
+func (c *networkContext) GetMeshHTTPClient() HTTPClient {
+	return c.network.getMeshHTTPClient()
+}
+
+func (c *networkContext) AddMeshAuthHeaders(req *http.Request) {
+	c.network.AddMeshAuthHeaders(req)
+}
+
+func (c *networkContext) HasMeshConnectivity(name string) bool {
+	return c.network.hasMeshConnectivity(name)
+}
+
+func (c *networkContext) GetOnlineMeshPeers() []string {
+	return c.network.NeighbourhoodOnlineNames()
+}
+
+func (c *networkContext) GetPeerInfo(names []string) []PeerInfo {
+	return c.network.getPeerInfo(names)
+}
+
+func (c *networkContext) GetOnlineStatus(name string) *OnlineState {
+	if c.network.local.Projections == nil {
+		return nil
+	}
+	return c.network.local.Projections.OnlineStatus().GetState(name)
+}
+
+func (c *networkContext) IsReadOnly() bool {
+	return c.network.ReadOnly
+}
+
+func (c *networkContext) IsBooting() bool {
+	return c.network.local.isBooting()
+}
+
+func (c *networkContext) EnsureProjectionsUpdated() {
+	if c.network.local.Projections != nil && !c.network.local.isBooting() {
+		c.network.local.Projections.OnlineStatus().RunOnce()
+	}
+}
+
+func (c *networkContext) Context() context.Context {
+	return c.network.ctx
+}
+
+// stashServiceContext extends NetworkContext with stash-specific methods.
+// This implements StashServiceDeps.
+type stashServiceContext struct {
+	networkContext
+}
+
+func (c *stashServiceContext) EmitSocialEvent(event SyncEvent) {
+	select {
+	case c.network.socialInbox <- event:
+	default:
+		logrus.Debugf("Social inbox full, skipping stash event")
+	}
+}
+
+// newStashServiceContext creates a StashServiceDeps adapter for the given Network.
+func newStashServiceContext(network *Network) StashServiceDeps {
+	return &stashServiceContext{
+		networkContext: networkContext{network: network},
+	}
+}

--- a/projection_clout.go
+++ b/projection_clout.go
@@ -106,8 +106,12 @@ func (p *CloutProjection) DeriveClout(observerSoul string, personality NaraPerso
 			// System observations affect the TARGET's clout
 			applyProjectionObservationClout(clout, record, weight)
 		case "service":
-			// Service events (e.g., storing stash) give positive clout to the actor
-			clout[record.Actor] += weight * 0.5
+			// Service events (like stash) give clout to the ACTOR (the helper)
+			if record.Reason == ReasonStashStored {
+				clout[record.Actor] += weight * 2.0 // generous reward for being helpful
+			} else {
+				clout[record.Actor] += weight * 0.5
+			}
 		}
 	}
 
@@ -177,6 +181,8 @@ func computeCloutEventWeight(record SocialEventRecord, personality NaraPersonali
 		weight *= 1.3
 	case ReasonJourneyTimeout:
 		weight *= 1.2
+	case ReasonStashStored:
+		weight *= 1.5
 	}
 
 	// Type-based adjustments

--- a/projection_clout.go
+++ b/projection_clout.go
@@ -105,6 +105,9 @@ func (p *CloutProjection) DeriveClout(observerSoul string, personality NaraPerso
 		case "observation":
 			// System observations affect the TARGET's clout
 			applyProjectionObservationClout(clout, record, weight)
+		case "service":
+			// Service events (e.g., storing stash) give positive clout to the actor
+			clout[record.Actor] += weight * 0.5
 		}
 	}
 

--- a/social.go
+++ b/social.go
@@ -22,6 +22,7 @@ const (
 	ReasonJourneyPass     = "journey-pass"     // a world journey passed through us
 	ReasonJourneyComplete = "journey-complete" // heard a journey completed
 	ReasonJourneyTimeout  = "journey-timeout"  // a journey we saw never completed
+	ReasonStashStored     = "stash-stored"     // confident stored stash for owner
 )
 
 // SocialEvent represents an immutable social fact in the network
@@ -68,6 +69,7 @@ func (e *SocialEvent) IsValid() bool {
 		"observed":    true,
 		"gossip":      true,
 		"observation": true, // system observations (online/offline, journey events)
+		"service":     true, // helpful actions like storing stash
 	}
 	return validTypes[e.Type]
 }

--- a/stash.go
+++ b/stash.go
@@ -1,0 +1,549 @@
+package nara
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+const (
+	// MaxStashSize is the maximum size of a stash payload (10KB)
+	MaxStashSize = 10 * 1024
+)
+
+// EmojiPool is the set of emojis to choose from for identity generation
+var EmojiPool = []string{
+	"🌸", "🌺", "🌻", "🌼", "🌷", "🪻", "🌹", "🥀", "💐", "🪷",
+	"🌳", "🌲", "🌴", "🌵", "🌾", "🌿", "🍀", "🍁", "🍂", "🍃",
+	"🍄", "🪨", "🌊", "🔥", "⭐", "🌙", "☀️", "🌈", "⚡", "❄️",
+	"🦋", "🐝", "🐛", "🦎", "🐢", "🐙", "🦑", "🦀", "🐠", "🐟",
+	"🦅", "🦆", "🦉", "🦇", "🐺", "🦊", "🐱", "🐶", "🐰", "🐻",
+}
+
+// StashData is what gets encrypted (timestamp inside for tamper-proofing)
+type StashData struct {
+	Timestamp int64    `json:"timestamp"` // When this stash was created
+	Emojis    []string `json:"emojis"`    // Random emoji sequence (identity token)
+	// Future: add more fields as needed
+}
+
+// Marshal serializes StashData to JSON
+func (s *StashData) Marshal() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+// Unmarshal deserializes StashData from JSON
+func (s *StashData) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, s)
+}
+
+// StashPayload is the encrypted blob stored by confidents
+type StashPayload struct {
+	Owner      string `json:"owner"`
+	Nonce      []byte `json:"nonce"`      // 24-byte XChaCha20 nonce
+	Ciphertext []byte `json:"ciphertext"` // Encrypted StashData
+}
+
+// Size returns the total size of the payload
+func (p *StashPayload) Size() int {
+	return len(p.Owner) + len(p.Nonce) + len(p.Ciphertext)
+}
+
+// StashStore is sent from owner to confident to store stash
+type StashStore struct {
+	From      string       `json:"from"`
+	Signature string       `json:"signature"` // Base64-encoded signature
+	Payload   StashPayload `json:"payload"`
+}
+
+// Sign signs the message with the given keypair
+func (s *StashStore) Sign(keypair NaraKeypair) {
+	// Sign the payload owner + ciphertext
+	data := s.dataToSign()
+	sig := keypair.Sign(data)
+	s.Signature = base64.StdEncoding.EncodeToString(sig)
+}
+
+// Verify verifies the message signature
+func (s *StashStore) Verify(publicKey []byte) bool {
+	sig, err := base64.StdEncoding.DecodeString(s.Signature)
+	if err != nil {
+		return false
+	}
+	data := s.dataToSign()
+	return VerifySignature(publicKey, data, sig)
+}
+
+func (s *StashStore) dataToSign() []byte {
+	// Include from + payload owner + ciphertext in signature
+	return append([]byte(s.From+":"+s.Payload.Owner+":"), s.Payload.Ciphertext...)
+}
+
+// StashStoreAck is sent from confident to owner to confirm storage
+type StashStoreAck struct {
+	From  string `json:"from"`
+	Owner string `json:"owner"`
+}
+
+// StashRequest is broadcast by owner to ask "who has my stash?"
+type StashRequest struct {
+	From      string `json:"from"`
+	Signature string `json:"signature"`
+}
+
+// Sign signs the request
+func (s *StashRequest) Sign(keypair NaraKeypair) {
+	data := []byte("stash_request:" + s.From)
+	sig := keypair.Sign(data)
+	s.Signature = base64.StdEncoding.EncodeToString(sig)
+}
+
+// Verify verifies the request signature
+func (s *StashRequest) Verify(publicKey []byte) bool {
+	sig, err := base64.StdEncoding.DecodeString(s.Signature)
+	if err != nil {
+		return false
+	}
+	data := []byte("stash_request:" + s.From)
+	return VerifySignature(publicKey, data, sig)
+}
+
+// StashResponse is sent from confident to owner with the stored stash
+type StashResponse struct {
+	From    string       `json:"from"`
+	Owner   string       `json:"owner"`
+	Payload StashPayload `json:"payload"`
+}
+
+// StashDelete is sent from owner to confident to delete their stash
+type StashDelete struct {
+	From      string `json:"from"`
+	Signature string `json:"signature"`
+}
+
+// Sign signs the delete request
+func (s *StashDelete) Sign(keypair NaraKeypair) {
+	data := []byte("stash_delete:" + s.From)
+	sig := keypair.Sign(data)
+	s.Signature = base64.StdEncoding.EncodeToString(sig)
+}
+
+// Verify verifies the delete request signature
+func (s *StashDelete) Verify(publicKey []byte) bool {
+	sig, err := base64.StdEncoding.DecodeString(s.Signature)
+	if err != nil {
+		return false
+	}
+	data := []byte("stash_delete:" + s.From)
+	return VerifySignature(publicKey, data, sig)
+}
+
+// ConfidentTracker tracks which confidents have our stash (owner side)
+type ConfidentTracker struct {
+	confidents  map[string]int64 // name -> timestamp they confirmed
+	targetCount int
+	mu          sync.RWMutex
+}
+
+// NewConfidentTracker creates a new tracker with the given target count
+func NewConfidentTracker(targetCount int) *ConfidentTracker {
+	return &ConfidentTracker{
+		confidents:  make(map[string]int64),
+		targetCount: targetCount,
+	}
+}
+
+// Add adds a confident with the given confirmation timestamp
+func (t *ConfidentTracker) Add(name string, timestamp int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.confidents[name] = timestamp
+}
+
+// Remove removes a confident
+func (t *ConfidentTracker) Remove(name string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.confidents, name)
+}
+
+// Has returns true if the given name is a tracked confident
+func (t *ConfidentTracker) Has(name string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	_, ok := t.confidents[name]
+	return ok
+}
+
+// Count returns the number of tracked confidents
+func (t *ConfidentTracker) Count() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.confidents)
+}
+
+// IsSatisfied returns true if we have at least targetCount confidents
+func (t *ConfidentTracker) IsSatisfied() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.confidents) >= t.targetCount
+}
+
+// NeedsMore returns true if we need more confidents
+func (t *ConfidentTracker) NeedsMore() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.confidents) < t.targetCount
+}
+
+// GetExcess returns confidents beyond the target count (oldest first)
+func (t *ConfidentTracker) GetExcess() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if len(t.confidents) <= t.targetCount {
+		return nil
+	}
+
+	// Sort by timestamp (oldest first)
+	type entry struct {
+		name string
+		ts   int64
+	}
+	entries := make([]entry, 0, len(t.confidents))
+	for name, ts := range t.confidents {
+		entries = append(entries, entry{name, ts})
+	}
+	// Sort ascending by timestamp
+	for i := 0; i < len(entries)-1; i++ {
+		for j := i + 1; j < len(entries); j++ {
+			if entries[j].ts < entries[i].ts {
+				entries[i], entries[j] = entries[j], entries[i]
+			}
+		}
+	}
+
+	// Return oldest entries beyond target
+	excess := make([]string, len(entries)-t.targetCount)
+	for i := 0; i < len(excess); i++ {
+		excess[i] = entries[i].name
+	}
+	return excess
+}
+
+// SelectRandom selects a random confident from online naras, excluding self and existing confidents
+func (t *ConfidentTracker) SelectRandom(self string, online []string) string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	// Build candidate list
+	candidates := make([]string, 0)
+	for _, name := range online {
+		if name == self {
+			continue
+		}
+		if _, exists := t.confidents[name]; exists {
+			continue
+		}
+		candidates = append(candidates, name)
+	}
+
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	return candidates[rand.Intn(len(candidates))]
+}
+
+// MarkOffline removes confidents that are no longer online
+func (t *ConfidentTracker) MarkOffline(name string, online []string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Check if the confident is still online
+	found := false
+	for _, n := range online {
+		if n == name {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		delete(t.confidents, name)
+	}
+}
+
+// GetAll returns all confident names
+func (t *ConfidentTracker) GetAll() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	names := make([]string, 0, len(t.confidents))
+	for name := range t.confidents {
+		names = append(names, name)
+	}
+	return names
+}
+
+// StashManager manages stash operations for the owner
+type StashManager struct {
+	ownerName        string
+	keypair          NaraKeypair
+	encKeypair       EncryptionKeypair
+	confidentTracker *ConfidentTracker
+
+	recoveredStash    *StashData
+	currentTimestamp  int64
+	hasRecoveredStash bool
+	shouldStartFresh  bool
+	mu                sync.RWMutex
+}
+
+// NewStashManager creates a new stash manager for the owner
+func NewStashManager(ownerName string, keypair NaraKeypair, targetConfidents int) *StashManager {
+	return &StashManager{
+		ownerName:        ownerName,
+		keypair:          keypair,
+		encKeypair:       DeriveEncryptionKeys(keypair.PrivateKey),
+		confidentTracker: NewConfidentTracker(targetConfidents),
+	}
+}
+
+// RequestStash broadcasts a stash request (implementation will be in network.go)
+func (m *StashManager) RequestStash(network *MockMeshNetwork, responses chan *StashResponse) {
+	// This is a placeholder - actual implementation will use MQTT
+	// For testing, responses come through the channel
+}
+
+// ProcessResponses processes stash responses and picks the newest
+func (m *StashManager) ProcessResponses(responses <-chan *StashResponse) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var newestData *StashData
+	var newestTimestamp int64
+
+	for resp := range responses {
+		// Decrypt and parse the payload
+		decrypted, err := m.encKeypair.DecryptForSelf(resp.Payload.Nonce, resp.Payload.Ciphertext)
+		if err != nil {
+			continue // Skip invalid responses
+		}
+
+		data := &StashData{}
+		if err := data.Unmarshal(decrypted); err != nil {
+			continue
+		}
+
+		// Skip if older than what we have
+		if data.Timestamp <= m.currentTimestamp {
+			continue
+		}
+
+		// Pick newest
+		if data.Timestamp > newestTimestamp {
+			newestTimestamp = data.Timestamp
+			newestData = data
+		}
+
+		// Track the confident
+		m.confidentTracker.Add(resp.From, time.Now().Unix())
+	}
+
+	if newestData != nil {
+		m.recoveredStash = newestData
+		m.hasRecoveredStash = true
+		m.currentTimestamp = newestTimestamp
+	}
+
+	return nil
+}
+
+// HasRecoveredStash returns true if we recovered a stash
+func (m *StashManager) HasRecoveredStash() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.hasRecoveredStash
+}
+
+// ShouldStartFresh returns true if we should start fresh (no stash recovered)
+func (m *StashManager) ShouldStartFresh() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return !m.hasRecoveredStash
+}
+
+// GetRecoveredTimestamp returns the timestamp of the recovered stash
+func (m *StashManager) GetRecoveredTimestamp() int64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.recoveredStash != nil {
+		return m.recoveredStash.Timestamp
+	}
+	return 0
+}
+
+// SetCurrentTimestamp sets the current timestamp (for rejecting stale stash)
+func (m *StashManager) SetCurrentTimestamp(ts int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.currentTimestamp = ts
+}
+
+// GetRecoveredEmojis returns the recovered emoji sequence, or nil if none
+func (m *StashManager) GetRecoveredEmojis() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.recoveredStash != nil {
+		return m.recoveredStash.Emojis
+	}
+	return nil
+}
+
+// GenerateRandomEmojis generates a random sequence of n emojis
+func GenerateRandomEmojis(n int) []string {
+	emojis := make([]string, n)
+	for i := 0; i < n; i++ {
+		emojis[i] = EmojiPool[rand.Intn(len(EmojiPool))]
+	}
+	return emojis
+}
+
+// ConfidentStashStore stores stash payloads in memory (confident side)
+type ConfidentStashStore struct {
+	stashes map[string]*StashPayload // owner -> payload
+	mu      sync.RWMutex
+}
+
+// NewConfidentStashStore creates a new in-memory stash store
+func NewConfidentStashStore() *ConfidentStashStore {
+	return &ConfidentStashStore{
+		stashes: make(map[string]*StashPayload),
+	}
+}
+
+// HandleStashStore handles an incoming StashStore message
+func (s *ConfidentStashStore) HandleStashStore(msg *StashStore, getPublicKey func(string) []byte) error {
+	// Verify signature
+	pubKey := getPublicKey(msg.From)
+	if pubKey == nil {
+		return errors.New("unknown sender")
+	}
+	if !msg.Verify(pubKey) {
+		return errors.New("invalid signature")
+	}
+
+	// Check size limit
+	if len(msg.Payload.Ciphertext) > MaxStashSize {
+		return errors.New("stash too large")
+	}
+
+	// Store it
+	s.Store(msg.From, &msg.Payload)
+	return nil
+}
+
+// Store stores a payload for the given owner
+func (s *ConfidentStashStore) Store(owner string, payload *StashPayload) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stashes[owner] = payload
+}
+
+// HasStashFor returns true if we have a stash for the given owner
+func (s *ConfidentStashStore) HasStashFor(owner string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.stashes[owner]
+	return ok
+}
+
+// CreateAck creates an ack message for the given owner
+func (s *ConfidentStashStore) CreateAck(owner string) *StashStoreAck {
+	return &StashStoreAck{
+		Owner: owner,
+	}
+}
+
+// HandleStashRequest handles a stash request and returns a response if we have the stash
+func (s *ConfidentStashStore) HandleStashRequest(req *StashRequest, getPublicKey func(string) []byte) *StashResponse {
+	// Verify signature
+	pubKey := getPublicKey(req.From)
+	if pubKey == nil {
+		return nil
+	}
+	if !req.Verify(pubKey) {
+		return nil
+	}
+
+	s.mu.RLock()
+	payload, ok := s.stashes[req.From]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil
+	}
+
+	return &StashResponse{
+		Owner:   req.From,
+		Payload: *payload,
+	}
+}
+
+// HandleStashDelete handles a delete request
+func (s *ConfidentStashStore) HandleStashDelete(msg *StashDelete, getPublicKey func(string) []byte) error {
+	// Verify signature
+	pubKey := getPublicKey(msg.From)
+	if pubKey == nil {
+		return errors.New("unknown sender")
+	}
+	if !msg.Verify(pubKey) {
+		return errors.New("invalid signature")
+	}
+
+	s.mu.Lock()
+	delete(s.stashes, msg.From)
+	s.mu.Unlock()
+
+	return nil
+}
+
+// CreateStashPayload creates an encrypted stash payload
+func CreateStashPayload(owner string, data *StashData, encKeypair EncryptionKeypair) (*StashPayload, error) {
+	// Serialize
+	serialized, err := data.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	// Encrypt
+	nonce, ciphertext, err := encKeypair.EncryptForSelf(serialized)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StashPayload{
+		Owner:      owner,
+		Nonce:      nonce,
+		Ciphertext: ciphertext,
+	}, nil
+}
+
+// ExtractStashTimestamp decrypts a payload and returns the timestamp
+func ExtractStashTimestamp(payload *StashPayload, encKeypair EncryptionKeypair) (int64, error) {
+	decrypted, err := encKeypair.DecryptForSelf(payload.Nonce, payload.Ciphertext)
+	if err != nil {
+		return 0, err
+	}
+
+	data := &StashData{}
+	if err := data.Unmarshal(decrypted); err != nil {
+		return 0, err
+	}
+
+	return data.Timestamp, nil
+}

--- a/stash.go
+++ b/stash.go
@@ -3,12 +3,13 @@ package nara
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"math/rand"
+	"net/http"
 	"sync"
 	"time"
 
@@ -20,18 +21,9 @@ const (
 	MaxStashSize = 10 * 1024
 )
 
-// EmojiPool is the set of emojis to choose from for identity generation
-var EmojiPool = []string{
-	"🌸", "🌺", "🌻", "🌼", "🌷", "🪻", "🌹", "🥀", "💐", "🪷",
-	"🌳", "🌲", "🌴", "🌵", "🌾", "🌿", "🍀", "🍁", "🍂", "🍃",
-	"🍄", "🪨", "🌊", "🔥", "⭐", "🌙", "☀️", "🌈", "⚡", "❄️",
-	"🦋", "🐝", "🐛", "🦎", "🐢", "🐙", "🦑", "🦀", "🐠", "🐟",
-	"🦅", "🦆", "🦉", "🦇", "🐺", "🦊", "🐱", "🐶", "🐰", "🐻",
-}
-
 // StashData is what gets encrypted (timestamp inside for tamper-proofing)
-// This stores arbitrary JSON data - NOT tied to emojis or any specific schema.
-// Naras can use this to store any JSON they want, distributed to confidants.
+// This stores arbitrary JSON data. Naras can use this to store any JSON they want,
+// distributed to confidants for recovery after restarts.
 type StashData struct {
 	Timestamp int64           `json:"timestamp"` // When this stash was created
 	Data      json.RawMessage `json:"data"`      // Arbitrary JSON payload (any valid JSON)
@@ -46,15 +38,6 @@ func (s *StashData) Marshal() ([]byte, error) {
 // Unmarshal deserializes StashData from JSON
 func (s *StashData) Unmarshal(data []byte) error {
 	return json.Unmarshal(data, s)
-}
-
-// MigrateEmojiStashToJSON converts legacy emoji-based stash data to JSON format
-// This helper is for backward compatibility with old stash data
-func MigrateEmojiStashToJSON(emojis []string) (json.RawMessage, error) {
-	data := map[string]interface{}{
-		"emojis": emojis,
-	}
-	return json.Marshal(data)
 }
 
 // StashPayload is the encrypted blob stored by confidants
@@ -136,26 +119,10 @@ type StashResponse struct {
 }
 
 // POST /stash/store - Owner stores stash with confidant
+// Note: Authentication is handled by meshAuthMiddleware (X-Nara-* headers).
+// The From field is only used for logging/debugging - handlers use getVerifiedSender().
 type StashStoreRequest struct {
-	From      string        `json:"from"`
-	Timestamp int64         `json:"timestamp"` // Unix timestamp (seconds)
-	Stash     *StashPayload `json:"stash"`
-	Signature string        `json:"signature"`
-}
-
-func (s *StashStoreRequest) Sign(keypair NaraKeypair) {
-	data := fmt.Sprintf("stash_store:%s:%d", s.From, s.Timestamp)
-	sig := keypair.Sign([]byte(data))
-	s.Signature = base64.StdEncoding.EncodeToString(sig)
-}
-
-func (s *StashStoreRequest) Verify(publicKey []byte) bool {
-	sig, err := base64.StdEncoding.DecodeString(s.Signature)
-	if err != nil {
-		return false
-	}
-	data := fmt.Sprintf("stash_store:%s:%d", s.From, s.Timestamp)
-	return VerifySignature(publicKey, []byte(data), sig)
+	Stash *StashPayload `json:"stash"`
 }
 
 type StashStoreResponse struct {
@@ -164,25 +131,10 @@ type StashStoreResponse struct {
 }
 
 // POST /stash/retrieve - Owner requests stash back from confidant
+// Note: Authentication is handled by meshAuthMiddleware (X-Nara-* headers).
+// No request body needed - sender identity comes from mesh auth.
 type StashRetrieveRequest struct {
-	From      string `json:"from"`
-	Timestamp int64  `json:"timestamp"`
-	Signature string `json:"signature"`
-}
-
-func (s *StashRetrieveRequest) Sign(keypair NaraKeypair) {
-	data := fmt.Sprintf("stash_retrieve:%s:%d", s.From, s.Timestamp)
-	sig := keypair.Sign([]byte(data))
-	s.Signature = base64.StdEncoding.EncodeToString(sig)
-}
-
-func (s *StashRetrieveRequest) Verify(publicKey []byte) bool {
-	sig, err := base64.StdEncoding.DecodeString(s.Signature)
-	if err != nil {
-		return false
-	}
-	data := fmt.Sprintf("stash_retrieve:%s:%d", s.From, s.Timestamp)
-	return VerifySignature(publicKey, []byte(data), sig)
+	// Empty - sender identity from mesh auth
 }
 
 type StashRetrieveResponse struct {
@@ -191,27 +143,11 @@ type StashRetrieveResponse struct {
 }
 
 // POST /stash/push - Confidant pushes stash to owner (hey-there recovery)
+// Note: Authentication is handled by meshAuthMiddleware (X-Nara-* headers).
+// Sender identity comes from mesh auth, not from request body.
 type StashPushRequest struct {
-	From      string        `json:"from"`
-	To        string        `json:"to"`
-	Timestamp int64         `json:"timestamp"`
-	Stash     *StashPayload `json:"stash"`
-	Signature string        `json:"signature"`
-}
-
-func (s *StashPushRequest) Sign(keypair NaraKeypair) {
-	data := fmt.Sprintf("stash_push:%s:%s:%d", s.From, s.To, s.Timestamp)
-	sig := keypair.Sign([]byte(data))
-	s.Signature = base64.StdEncoding.EncodeToString(sig)
-}
-
-func (s *StashPushRequest) Verify(publicKey []byte) bool {
-	sig, err := base64.StdEncoding.DecodeString(s.Signature)
-	if err != nil {
-		return false
-	}
-	data := fmt.Sprintf("stash_push:%s:%s:%d", s.From, s.To, s.Timestamp)
-	return VerifySignature(publicKey, []byte(data), sig)
+	To    string        `json:"to"`
+	Stash *StashPayload `json:"stash"`
 }
 
 type StashPushResponse struct {
@@ -220,25 +156,10 @@ type StashPushResponse struct {
 }
 
 // DELETE /stash/store - Owner requests confidant to delete stash
+// Note: Authentication is handled by meshAuthMiddleware (X-Nara-* headers).
+// No request body needed - sender identity comes from mesh auth.
 type StashDeleteRequest struct {
-	From      string `json:"from"`
-	Timestamp int64  `json:"timestamp"`
-	Signature string `json:"signature"`
-}
-
-func (s *StashDeleteRequest) Sign(keypair NaraKeypair) {
-	data := fmt.Sprintf("stash_delete:%s:%d", s.From, s.Timestamp)
-	sig := keypair.Sign([]byte(data))
-	s.Signature = base64.StdEncoding.EncodeToString(sig)
-}
-
-func (s *StashDeleteRequest) Verify(publicKey []byte) bool {
-	sig, err := base64.StdEncoding.DecodeString(s.Signature)
-	if err != nil {
-		return false
-	}
-	data := fmt.Sprintf("stash_delete:%s:%d", s.From, s.Timestamp)
-	return VerifySignature(publicKey, []byte(data), sig)
+	// Empty - sender identity from mesh auth
 }
 
 type StashDeleteResponse struct {
@@ -371,6 +292,14 @@ func (t *ConfidantTracker) IsPending(name string) bool {
 	return ok
 }
 
+// IsFailed returns true if the given name is marked as failed
+func (t *ConfidantTracker) IsFailed(name string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	_, ok := t.failed[name]
+	return ok
+}
+
 // Count returns the number of tracked confidants
 func (t *ConfidantTracker) Count() int {
 	t.mu.RLock()
@@ -445,8 +374,8 @@ type PeerInfo struct {
 	UptimeSecs int64
 }
 
-// SelectRandom selects a random confidant from online naras, excluding self, existing, and pending confidants
-// Deprecated: Use SelectBest for smarter selection based on memory mode and uptime
+// SelectRandom selects a random confidant from available peers (by name)
+// Excludes self, existing confidants, pending, and failed peers
 func (t *ConfidantTracker) SelectRandom(self string, online []string) string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -463,6 +392,9 @@ func (t *ConfidantTracker) SelectRandom(self string, online []string) string {
 		if _, pending := t.pending[name]; pending {
 			continue
 		}
+		if _, failed := t.failed[name]; failed {
+			continue
+		}
 		candidates = append(candidates, name)
 	}
 
@@ -471,6 +403,16 @@ func (t *ConfidantTracker) SelectRandom(self string, online []string) string {
 	}
 
 	return candidates[rand.Intn(len(candidates))]
+}
+
+// SelectRandomFromPeers is a wrapper around SelectRandom for PeerInfo slices
+// Used in confidant selection to pick random peers for better distribution
+func (t *ConfidantTracker) SelectRandomFromPeers(self string, peers []PeerInfo) string {
+	names := make([]string, len(peers))
+	for i, p := range peers {
+		names[i] = p.Name
+	}
+	return t.SelectRandom(self, names)
 }
 
 // SelectBest selects the best confidant from available peers based on memory mode and uptime
@@ -704,15 +646,6 @@ func (m *StashManager) HasStashData() bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.currentStash != nil && len(m.currentStash.Data) > 0
-}
-
-// GenerateRandomEmojis generates a random sequence of n emojis
-func GenerateRandomEmojis(n int) []string {
-	emojis := make([]string, n)
-	for i := 0; i < n; i++ {
-		emojis[i] = EmojiPool[rand.Intn(len(EmojiPool))]
-	}
-	return emojis
 }
 
 // ConfidantStashStore stores stash payloads in memory (confidant side)
@@ -1005,6 +938,7 @@ type StashMetrics struct {
 	ConfidantCount       int   // Number of confidants storing my stash
 	TargetConfidantCount int   // Target (usually 2-3)
 	EvictionCount        int   // Number of ghost prunings (stashes removed when owner offline 7+ days)
+	StorageLimit         int   // Maximum number of stashes we can store
 }
 
 // GetMetrics returns current storage metrics
@@ -1016,6 +950,7 @@ func (s *ConfidantStashStore) GetMetrics() StashMetrics {
 		StashesStored:   len(s.stashes),
 		TotalStashBytes: s.totalBytes,
 		EvictionCount:   s.evictionCount,
+		StorageLimit:    s.maxStashes,
 	}
 }
 
@@ -1036,4 +971,741 @@ func StashStorageForMemoryMode(mode MemoryMode) int {
 	default:
 		return StashStorageMedium
 	}
+}
+
+// =============================================================================
+// StashService - Unified stash business logic layer
+// =============================================================================
+
+// StashServiceDeps extends NetworkContext with stash-specific functionality.
+// This interface allows the service to be decoupled from Network while still
+// accessing necessary functionality.
+type StashServiceDeps interface {
+	NetworkContext
+
+	// Stash-specific: emit social events for stash operations
+	EmitSocialEvent(event SyncEvent)
+}
+
+// StashService encapsulates all stash business logic for both owner and confidant roles.
+// It provides a clean API for HTTP handlers and network operations to use.
+//
+// Architecture:
+//
+//	StashService (orchestration layer - all business logic)
+//	├── StashManager        (owner side: MY stash → distributed to confidants)
+//	├── ConfidantStashStore (confidant side: OTHERS' stashes → stored by me)
+//	└── StashSyncTracker    (rate limiting sync operations)
+//
+// - StashManager: Manages YOUR OWN stash data and tracks which confidants hold copies.
+// - ConfidantStashStore: Stores OTHER naras' stashes when you act as their confidant.
+// - StashService: Wraps both and provides all operations (accept, retrieve, distribute, etc.)
+type StashService struct {
+	// Owner-side: manages OUR stash that we distribute to confidants
+	manager *StashManager
+
+	// Confidant-side: stores OTHER naras' stashes (we're their confidant)
+	confidantStore *ConfidantStashStore
+
+	// Rate limiting for stash sync operations
+	syncTracker *StashSyncTracker
+
+	// External dependencies
+	deps StashServiceDeps
+}
+
+// NewStashService creates a new StashService with the given components.
+// Pass nil for components that aren't needed (e.g., nil manager if not using stash).
+func NewStashService(
+	manager *StashManager,
+	confidantStore *ConfidantStashStore,
+	syncTracker *StashSyncTracker,
+	deps StashServiceDeps,
+) *StashService {
+	return &StashService{
+		manager:        manager,
+		confidantStore: confidantStore,
+		syncTracker:    syncTracker,
+		deps:           deps,
+	}
+}
+
+// =============================================================================
+// Confidant-side operations (storing stashes for others)
+// =============================================================================
+
+// AcceptStash handles an incoming stash store request from an owner.
+// Returns whether the stash was accepted and a reason if rejected.
+func (s *StashService) AcceptStash(owner string, stash *StashPayload) (accepted bool, reason string) {
+	if s.confidantStore == nil {
+		return false, "stash_disabled"
+	}
+
+	if stash == nil {
+		return false, "stash_required"
+	}
+
+	if stash.Size() > MaxStashSize {
+		logrus.Warnf("📦 Rejected stash from %s: too large (%d bytes)", owner, stash.Size())
+		return false, "stash_too_large"
+	}
+
+	// Try to store (returns false if at capacity)
+	if !s.confidantStore.Store(owner, stash) {
+		metrics := s.confidantStore.GetMetrics()
+		logrus.Warnf("📦 Rejected stash from %s: at capacity (%d/%d)",
+			owner, metrics.StashesStored, s.confidantStore.maxStashes)
+		return false, "at_capacity"
+	}
+
+	logrus.Infof("📦 Accepted stash for %s (%d bytes)", owner, stash.Size())
+
+	// Emit social event for storing stash
+	if s.deps != nil {
+		socialEvent := SocialEventPayload{
+			Type:    "service",
+			Actor:   s.deps.MyName(),
+			Target:  owner,
+			Reason:  ReasonStashStored,
+			Witness: s.deps.MyName(),
+		}
+		syncEvent := SyncEvent{
+			Service:   ServiceSocial,
+			Timestamp: time.Now().UnixNano(),
+			Emitter:   s.deps.MyName(),
+			Social:    &socialEvent,
+		}
+		s.deps.EmitSocialEvent(syncEvent)
+	}
+
+	return true, ""
+}
+
+// RetrieveStashFor returns the stored stash for the given owner, or nil if not found.
+func (s *StashService) RetrieveStashFor(owner string) *StashPayload {
+	if s.confidantStore == nil {
+		return nil
+	}
+
+	s.confidantStore.mu.RLock()
+	payload := s.confidantStore.stashes[owner]
+	s.confidantStore.mu.RUnlock()
+
+	if payload != nil {
+		logrus.Infof("📦 Sent stash to %s (%d bytes)", owner, payload.Size())
+	}
+
+	return payload
+}
+
+// DeleteStashFor removes the stored stash for the given owner.
+// Returns true if a stash was deleted, false if none existed.
+func (s *StashService) DeleteStashFor(owner string) bool {
+	if s.confidantStore == nil {
+		return false
+	}
+
+	deleted := s.confidantStore.Delete(owner)
+	if deleted {
+		logrus.Infof("📦 Deleted stash for %s", owner)
+	}
+
+	return deleted
+}
+
+// HasStashFor returns true if we have a stash stored for the given owner.
+func (s *StashService) HasStashFor(owner string) bool {
+	if s.confidantStore == nil {
+		return false
+	}
+	return s.confidantStore.HasStashFor(owner)
+}
+
+// AcceptPushedStash handles receiving a stash push during recovery.
+// It decrypts the stash, stores it locally, and marks the sender as a confidant.
+func (s *StashService) AcceptPushedStash(sender string, stash *StashPayload) (accepted bool, reason string) {
+	if s.manager == nil {
+		return false, "stash_disabled"
+	}
+
+	if stash == nil {
+		return false, "stash_required"
+	}
+
+	// Decrypt the stash
+	encKeypair := DeriveEncryptionKeys(s.deps.Keypair().PrivateKey)
+	stashData, err := DecryptStashPayload(stash, encKeypair)
+	if err != nil {
+		logrus.Warnf("📦 Failed to decrypt pushed stash from %s: %v", sender, err)
+		return false, "decrypt_failed"
+	}
+
+	// Store recovered stash
+	s.manager.SetCurrentStash(stashData.Data)
+	logrus.Infof("📦 Recovered stash from %s via push (%d bytes, timestamp=%d)",
+		sender, len(stashData.Data), stashData.Timestamp)
+
+	// Mark them as a confidant
+	if s.manager.confidantTracker != nil {
+		s.manager.confidantTracker.Add(sender, time.Now().Unix())
+	}
+
+	return true, ""
+}
+
+// =============================================================================
+// Owner-side operations (managing our stash distribution)
+// =============================================================================
+
+// SetCurrentStash updates the owner's current stash data.
+func (s *StashService) SetCurrentStash(data json.RawMessage) {
+	if s.manager != nil {
+		s.manager.SetCurrentStash(data)
+	}
+}
+
+// GetCurrentStash returns the owner's current stash data.
+func (s *StashService) GetCurrentStash() *StashData {
+	if s.manager == nil {
+		return nil
+	}
+	return s.manager.GetCurrentStash()
+}
+
+// HasStashData returns true if the owner has stash data to distribute.
+func (s *StashService) HasStashData() bool {
+	return s.manager != nil && s.manager.HasStashData()
+}
+
+// GetConfidants returns the list of confirmed confidant names.
+func (s *StashService) GetConfidants() []string {
+	if s.manager == nil || s.manager.confidantTracker == nil {
+		return nil
+	}
+	return s.manager.confidantTracker.GetAll()
+}
+
+// ConfidantCount returns the number of confirmed confidants.
+func (s *StashService) ConfidantCount() int {
+	if s.manager == nil || s.manager.confidantTracker == nil {
+		return 0
+	}
+	return s.manager.confidantTracker.Count()
+}
+
+// TargetConfidantCount returns the target number of confidants.
+func (s *StashService) TargetConfidantCount() int {
+	if s.manager == nil || s.manager.confidantTracker == nil {
+		return 0
+	}
+	return s.manager.confidantTracker.targetCount
+}
+
+// MarkConfidantConfirmed marks a confidant as having confirmed storage of our stash.
+func (s *StashService) MarkConfidantConfirmed(name string, timestamp int64) {
+	if s.manager != nil && s.manager.confidantTracker != nil {
+		s.manager.confidantTracker.Add(name, timestamp)
+	}
+}
+
+// MarkConfidantFailed marks a confidant as having failed (timeout, rejection, etc).
+func (s *StashService) MarkConfidantFailed(name string) {
+	if s.manager != nil && s.manager.confidantTracker != nil {
+		s.manager.confidantTracker.MarkFailed(name)
+	}
+}
+
+// =============================================================================
+// Metrics and status
+// =============================================================================
+
+// GetStorageMetrics returns metrics about stash storage (confidant role).
+func (s *StashService) GetStorageMetrics() StashMetrics {
+	if s.confidantStore == nil {
+		return StashMetrics{}
+	}
+	return s.confidantStore.GetMetrics()
+}
+
+// GetAllStoredOwners returns the list of owners we're storing stashes for.
+func (s *StashService) GetAllStoredOwners() []string {
+	if s.confidantStore == nil {
+		return nil
+	}
+	return s.confidantStore.GetAllOwners()
+}
+
+// =============================================================================
+// Owner-side HTTP operations (distributing stash to confidants)
+// =============================================================================
+
+// ExchangeStashWithPeer performs bidirectional stash exchange with a peer.
+// - If we have stash data and need storage, we store with them
+// - If we don't have stash data, we try to retrieve from them
+func (s *StashService) ExchangeStashWithPeer(targetName string) {
+	// Check rate limiting - don't sync more than once per 5 minutes
+	if s.syncTracker != nil && !s.syncTracker.ShouldSync(targetName, 5*time.Minute) {
+		return
+	}
+
+	if s.manager == nil || s.manager.confidantTracker == nil {
+		return
+	}
+
+	// First, try to store our stash with them if needed
+	needsStorage := s.manager.confidantTracker.Has(targetName) || s.manager.confidantTracker.NeedsMore()
+	if needsStorage && s.manager.HasStashData() && !s.manager.confidantTracker.IsFailed(targetName) {
+		s.StoreStashWithPeer(targetName)
+	}
+
+	// Second, try to retrieve our stash if we don't have it
+	if !s.manager.HasStashData() {
+		s.RetrieveStashFromPeer(targetName)
+	}
+
+	// Mark sync timestamp
+	if s.syncTracker != nil {
+		s.syncTracker.MarkSyncNow(targetName)
+	}
+}
+
+// StoreStashWithPeer sends our stash to a peer for storage.
+func (s *StashService) StoreStashWithPeer(targetName string) {
+	if s.manager == nil || s.deps == nil {
+		return
+	}
+
+	// Determine base URL
+	baseURL := s.deps.BuildMeshURL(targetName, "")
+	if baseURL == "" {
+		return
+	}
+
+	currentStash := s.manager.GetCurrentStash()
+	if currentStash == nil {
+		return
+	}
+
+	encKeypair := DeriveEncryptionKeys(s.deps.Keypair().PrivateKey)
+	payload, err := CreateStashPayload(s.deps.MyName(), currentStash, encKeypair)
+	if err != nil {
+		logrus.Debugf("📦 Failed to create stash payload: %v", err)
+		return
+	}
+
+	// Build request (auth is in mesh headers, not body)
+	req := StashStoreRequest{
+		Stash: payload,
+	}
+
+	reqBytes, _ := json.Marshal(req)
+	ctx, cancel := context.WithTimeout(s.deps.Context(), 10*time.Second)
+	defer cancel()
+
+	httpReq, _ := http.NewRequestWithContext(ctx, "POST", baseURL+"/stash/store", bytes.NewBuffer(reqBytes))
+	httpReq.Header.Set("Content-Type", "application/json")
+	s.deps.AddMeshAuthHeaders(httpReq)
+
+	client := s.deps.GetMeshHTTPClient()
+	if client == nil {
+		return
+	}
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		logrus.Debugf("📦 Failed to store stash with %s: %v", targetName, err)
+		s.manager.confidantTracker.MarkFailed(targetName)
+		return
+	}
+	defer resp.Body.Close()
+
+	var response StashStoreResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err == nil && response.Accepted {
+		s.manager.confidantTracker.Add(targetName, time.Now().Unix())
+		logrus.Infof("📦 %s accepted stash", targetName)
+	} else if !response.Accepted {
+		logrus.Warnf("📦 %s rejected stash: %s", targetName, response.Reason)
+		s.manager.confidantTracker.MarkFailed(targetName)
+	}
+}
+
+// RetrieveStashFromPeer requests our stash back from a peer.
+func (s *StashService) RetrieveStashFromPeer(targetName string) {
+	if s.manager == nil || s.deps == nil {
+		return
+	}
+
+	// Determine base URL
+	baseURL := s.deps.BuildMeshURL(targetName, "")
+	if baseURL == "" {
+		return
+	}
+
+	// Auth is in mesh headers, body can be empty
+	ctx, cancel := context.WithTimeout(s.deps.Context(), 10*time.Second)
+	defer cancel()
+
+	httpReq, _ := http.NewRequestWithContext(ctx, "POST", baseURL+"/stash/retrieve", nil)
+	httpReq.Header.Set("Content-Type", "application/json")
+	s.deps.AddMeshAuthHeaders(httpReq)
+
+	client := s.deps.GetMeshHTTPClient()
+	if client == nil {
+		return
+	}
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		logrus.Debugf("📦 Failed to retrieve stash from %s: %v", targetName, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	var response StashRetrieveResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err == nil && response.Found {
+		encKeypair := DeriveEncryptionKeys(s.deps.Keypair().PrivateKey)
+		stashData, err := DecryptStashPayload(response.Stash, encKeypair)
+		if err == nil {
+			s.manager.SetCurrentStash(stashData.Data)
+			s.manager.confidantTracker.Add(targetName, time.Now().Unix())
+			logrus.Infof("📦 Recovered stash from %s (%d bytes)", targetName, len(stashData.Data))
+		}
+	}
+}
+
+// PushStashToOwner pushes a stash back to its owner via HTTP POST to /stash/push.
+// This is called during hey-there recovery or stash-refresh requests.
+// Runs the push in a background goroutine with optional delay.
+func (s *StashService) PushStashToOwner(targetName string, delay time.Duration) {
+	go func() {
+		// Optional delay to let them finish booting or avoid thundering herd
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+
+		// Check if we still have their stash
+		if s.confidantStore == nil || s.deps == nil {
+			return
+		}
+
+		s.confidantStore.mu.RLock()
+		theirStash := s.confidantStore.stashes[targetName]
+		s.confidantStore.mu.RUnlock()
+
+		if theirStash == nil {
+			logrus.Debugf("📦 No stash found for %s during push", targetName)
+			return
+		}
+
+		// Build push request (auth is in mesh headers, not body)
+		req := StashPushRequest{
+			To:    targetName,
+			Stash: theirStash,
+		}
+
+		// Determine URL
+		url := s.deps.BuildMeshURL(targetName, "/stash/push")
+		if url == "" {
+			logrus.Debugf("📦 Cannot push stash to %s: not reachable via mesh", targetName)
+			return
+		}
+
+		// Send push request
+		reqBytes, _ := json.Marshal(req)
+		ctx, cancel := context.WithTimeout(s.deps.Context(), 10*time.Second)
+		defer cancel()
+
+		httpReq, _ := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBytes))
+		httpReq.Header.Set("Content-Type", "application/json")
+		s.deps.AddMeshAuthHeaders(httpReq)
+
+		client := s.deps.GetMeshHTTPClient()
+		if client == nil {
+			return
+		}
+
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			logrus.Debugf("📦 Failed to push stash to %s: %v", targetName, err)
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			logrus.Infof("📦 Pushed stash to %s (recovery)", targetName)
+		}
+	}()
+}
+
+// =============================================================================
+// Maintenance operations
+// =============================================================================
+
+// MaintainConfidants ensures we have the target number of confidants for our stash.
+// It cleans up expired pending/failed entries and actively searches for new confidants if needed.
+func (s *StashService) MaintainConfidants() {
+	if s.manager == nil || s.deps == nil || s.deps.IsReadOnly() {
+		return
+	}
+
+	// Only maintain confidants if we have data to store
+	if !s.manager.HasStashData() {
+		return
+	}
+
+	tracker := s.manager.confidantTracker
+
+	// Cleanup expired pending (didn't ack in time - probably old version or offline)
+	expired := tracker.CleanupExpiredPending()
+	for _, name := range expired {
+		logrus.Debugf("📦 %s didn't ack stash (timeout), removed from pending", name)
+	}
+
+	// Cleanup expired failures (allow retrying after backoff period)
+	recovered := tracker.CleanupExpiredFailures()
+	for _, name := range recovered {
+		logrus.Debugf("📦 %s failure backoff expired, can retry", name)
+	}
+
+	// If we have stash data but less than target confidants, actively try to find more
+	if tracker.NeedsMore() {
+		needed := tracker.NeedsCount()
+		logrus.Debugf("📦 Need %d more confidants (have %d/%d), searching for candidates",
+			needed, tracker.Count(), tracker.targetCount)
+
+		// Get online naras
+		online := s.deps.GetOnlineMeshPeers()
+
+		// Filter to mesh-enabled only
+		var meshEnabled []string
+		for _, name := range online {
+			if s.deps.HasMeshConnectivity(name) {
+				meshEnabled = append(meshEnabled, name)
+			}
+		}
+
+		if len(meshEnabled) == 0 {
+			return
+		}
+
+		// Get peer info for selection
+		peers := s.deps.GetPeerInfo(meshEnabled)
+		if len(peers) == 0 {
+			return
+		}
+
+		// Try to find and store with confidants
+		// Strategy: First confidant uses best score (reliable high-memory nara)
+		//           Remaining confidants are random (better distribution, avoid hotspots)
+		// Keep trying peers until we fill all slots OR run out of candidates
+		attemptCount := 0
+		for tracker.NeedsMore() && len(peers) > 0 && attemptCount < 20 {
+			attemptCount++
+			var selectedName string
+			var selectionMethod string
+
+			currentCount := tracker.Count()
+			if currentCount == 0 {
+				// First confidant: pick the best (highest memory + uptime)
+				selectedName = tracker.SelectBest(s.deps.MyName(), peers)
+				selectionMethod = "best"
+			} else {
+				// Remaining confidants: pick randomly (distribute load)
+				selectedName = tracker.SelectRandomFromPeers(s.deps.MyName(), peers)
+				selectionMethod = "random"
+			}
+
+			if selectedName == "" {
+				break // No more candidates
+			}
+
+			logrus.Debugf("📦 Selected %s as confidant candidate (%s, attempt %d)", selectedName, selectionMethod, attemptCount)
+
+			// Try to store stash with this peer
+			// StoreStashWithPeer handles marking as pending/failed
+			s.StoreStashWithPeer(selectedName)
+
+			// Remove this peer from consideration (avoid retrying in same round)
+			newPeers := make([]PeerInfo, 0, len(peers)-1)
+			for _, p := range peers {
+				if p.Name != selectedName {
+					newPeers = append(newPeers, p)
+				}
+			}
+			peers = newPeers
+		}
+	}
+}
+
+// CheckConfidantHealth monitors the health of our confidants and removes offline ones.
+// Replacements will be found by MaintainConfidants in the next tick.
+func (s *StashService) CheckConfidantHealth() {
+	if s.manager == nil || s.manager.confidantTracker == nil || s.deps == nil {
+		return
+	}
+
+	// Get current confirmed confidants
+	confidants := s.manager.confidantTracker.GetAll()
+	if len(confidants) == 0 {
+		return
+	}
+
+	// Ensure projection is up-to-date before checking statuses
+	s.deps.EnsureProjectionsUpdated()
+
+	// Check each confidant's status
+	for _, confidantName := range confidants {
+		state := s.deps.GetOnlineStatus(confidantName)
+		if state == nil {
+			// Never seen - remove them
+			s.manager.confidantTracker.Remove(confidantName)
+			logrus.Warnf("📦 Confidant %s removed (never seen)", confidantName)
+			continue
+		}
+
+		// If offline or missing, remove them
+		if state.Status == "OFFLINE" || state.Status == "MISSING" {
+			s.manager.confidantTracker.Remove(confidantName)
+			logrus.Warnf("📦 Confidant %s went offline, will find replacement", confidantName)
+		}
+	}
+
+	// MaintainConfidants() will automatically find replacements in the next tick
+}
+
+// ReactToConfidantOffline is called immediately when we detect a nara went offline.
+// If they're one of our confidants, remove them and trigger immediate replacement search.
+func (s *StashService) ReactToConfidantOffline(name string) {
+	if s.manager == nil || s.manager.confidantTracker == nil {
+		return
+	}
+
+	// Check if this nara is one of our confidants
+	if !s.manager.confidantTracker.Has(name) {
+		return
+	}
+
+	// Remove them immediately
+	s.manager.confidantTracker.Remove(name)
+	logrus.Warnf("📦 Confidant %s went offline (reactive), finding replacement immediately", name)
+
+	// Trigger immediate replacement search
+	go s.MaintainConfidants()
+}
+
+// PruneGhostStashes removes stashes of owners who have been offline for 7+ days.
+func (s *StashService) PruneGhostStashes() {
+	if s.confidantStore == nil || s.deps == nil {
+		return
+	}
+
+	// Check all stash owners
+	owners := s.confidantStore.GetAllOwners()
+	if len(owners) == 0 {
+		return
+	}
+
+	// Ensure projection is up-to-date before checking statuses
+	s.deps.EnsureProjectionsUpdated()
+
+	isGhost := func(name string) bool {
+		// Check online status projection
+		state := s.deps.GetOnlineStatus(name)
+		if state == nil {
+			// No state = never seen = ghost
+			return true
+		}
+
+		// If online, definitely not a ghost
+		if state.Status == "ONLINE" {
+			return false
+		}
+
+		// If offline, check how long
+		lastSeen := state.LastEventTime
+		elapsedNanos := time.Now().UnixNano() - lastSeen
+		elapsed := time.Duration(elapsedNanos)
+
+		// Ghost if offline for more than 7 days
+		return elapsed > 7*24*time.Hour
+	}
+
+	evicted := s.confidantStore.EvictGhosts(isGhost)
+	if evicted > 0 {
+		logrus.Infof("📦 Pruned %d ghost stashes (offline 7+ days)", evicted)
+	}
+}
+
+// =============================================================================
+// Maintenance loop
+// =============================================================================
+
+// RunMaintenanceLoop runs the stash maintenance loop.
+// It should be called as a goroutine. The loop handles:
+// - Immediate stash distribution when triggered
+// - Periodic confidant health checks
+// - Periodic ghost stash pruning
+// - Periodic metrics logging
+func (s *StashService) RunMaintenanceLoop(trigger <-chan struct{}) {
+	if s.deps == nil {
+		return
+	}
+
+	// Prune ghost stashes on boot (naras offline >7 days)
+	s.PruneGhostStashes()
+
+	// Run every 5 minutes
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-trigger:
+			// Immediate stash distribution triggered (e.g., stash data updated)
+			logrus.Debugf("📦 Triggered immediate stash distribution")
+			s.MaintainConfidants()
+		case <-ticker.C:
+			// Periodic maintenance
+			// Check health of our confidants and find replacements if needed
+			s.CheckConfidantHealth()
+
+			// Maintain target number of confidants
+			s.MaintainConfidants()
+
+			// Prune ghost stashes periodically
+			s.PruneGhostStashes()
+
+			// Log stash metrics every 5 minutes
+			s.LogMetrics()
+		case <-s.deps.Context().Done():
+			return
+		}
+	}
+}
+
+// LogMetrics logs stash storage metrics.
+func (s *StashService) LogMetrics() {
+	if s.confidantStore == nil {
+		return
+	}
+
+	metrics := s.confidantStore.GetMetrics()
+	myConfidants := s.ConfidantCount()
+	targetConfidants := s.TargetConfidantCount()
+
+	// Calculate my stash size from actual stash data
+	var myStashSize int
+	if s.manager != nil {
+		currentStash := s.manager.GetCurrentStash()
+		if currentStash != nil {
+			myStashSize = len(currentStash.Data)
+		}
+	}
+
+	logrus.Infof("📦 Stash metrics: stored=%d (%.1fMB), my_confidants=%d/%d, my_size=%.1fKB",
+		metrics.StashesStored,
+		float64(metrics.TotalStashBytes)/1024/1024,
+		myConfidants,
+		targetConfidants,
+		float64(myStashSize)/1024)
 }

--- a/stash_sync_tracker.go
+++ b/stash_sync_tracker.go
@@ -1,0 +1,53 @@
+package nara
+
+import (
+	"sync"
+	"time"
+)
+
+// StashSyncTracker tracks when we last synced stashes with each peer (memory-only)
+// This prevents over-syncing while keeping Nara's no-persistence principle
+type StashSyncTracker struct {
+	lastSyncPerPeer map[string]int64 // peer -> last sync timestamp (unix seconds)
+	mu              sync.RWMutex
+}
+
+// NewStashSyncTracker creates a new memory-only sync tracker
+func NewStashSyncTracker() *StashSyncTracker {
+	return &StashSyncTracker{
+		lastSyncPerPeer: make(map[string]int64),
+	}
+}
+
+// UpdateLastSync records that we synced with a peer at the given time
+func (t *StashSyncTracker) UpdateLastSync(peer string, timestamp int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastSyncPerPeer[peer] = timestamp
+}
+
+// GetLastSync returns when we last synced with a peer (0 if never)
+func (t *StashSyncTracker) GetLastSync(peer string) int64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.lastSyncPerPeer[peer]
+}
+
+// ShouldSync returns true if we should sync with this peer based on minimum interval
+func (t *StashSyncTracker) ShouldSync(peer string, minInterval time.Duration) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	lastSync := t.lastSyncPerPeer[peer]
+	if lastSync == 0 {
+		return true // Never synced
+	}
+
+	elapsed := time.Now().Unix() - lastSync
+	return elapsed >= int64(minInterval.Seconds())
+}
+
+// MarkSyncNow marks that we're syncing with a peer right now
+func (t *StashSyncTracker) MarkSyncNow(peer string) {
+	t.UpdateLastSync(peer, time.Now().Unix())
+}

--- a/stash_test.go
+++ b/stash_test.go
@@ -1,0 +1,1081 @@
+package nara
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Test hardware fingerprints for stash testing
+var (
+	stashHW1 = hashBytes([]byte("stash-test-hw-1"))
+	stashHW2 = hashBytes([]byte("stash-test-hw-2"))
+	stashHW3 = hashBytes([]byte("stash-test-hw-3"))
+)
+
+// =====================================================
+// Crypto Tests
+// =====================================================
+
+func TestDeriveEncryptionKeys(t *testing.T) {
+	// Derive encryption keys from an Ed25519 private key
+	soul := NativeSoulCustom(stashHW1, "alice")
+	signingKeypair := DeriveKeypair(soul)
+
+	encKeypair := DeriveEncryptionKeys(signingKeypair.PrivateKey)
+
+	// Should have 32-byte symmetric key
+	if len(encKeypair.SymmetricKey) != 32 {
+		t.Errorf("Expected 32-byte symmetric key, got %d", len(encKeypair.SymmetricKey))
+	}
+
+	// Should be deterministic
+	encKeypair2 := DeriveEncryptionKeys(signingKeypair.PrivateKey)
+	if !bytes.Equal(encKeypair.SymmetricKey, encKeypair2.SymmetricKey) {
+		t.Error("Encryption key derivation should be deterministic")
+	}
+
+	// Different souls should produce different keys
+	otherSoul := NativeSoulCustom(stashHW2, "bob")
+	otherSigningKeypair := DeriveKeypair(otherSoul)
+	otherEncKeypair := DeriveEncryptionKeys(otherSigningKeypair.PrivateKey)
+
+	if bytes.Equal(encKeypair.SymmetricKey, otherEncKeypair.SymmetricKey) {
+		t.Error("Different souls should produce different encryption keys")
+	}
+}
+
+func TestEncryptDecryptForSelf(t *testing.T) {
+	// Create encryption keys
+	soul := NativeSoulCustom(stashHW1, "alice")
+	signingKeypair := DeriveKeypair(soul)
+	encKeypair := DeriveEncryptionKeys(signingKeypair.PrivateKey)
+
+	// Encrypt some data
+	plaintext := []byte("hello, this is my secret stash data!")
+	nonce, ciphertext, err := encKeypair.EncryptForSelf(plaintext)
+	if err != nil {
+		t.Fatalf("Encryption failed: %v", err)
+	}
+
+	// Nonce should be 24 bytes (XChaCha20)
+	if len(nonce) != 24 {
+		t.Errorf("Expected 24-byte nonce, got %d", len(nonce))
+	}
+
+	// Ciphertext should be larger than plaintext (includes auth tag)
+	if len(ciphertext) <= len(plaintext) {
+		t.Error("Ciphertext should be larger than plaintext")
+	}
+
+	// Decrypt should return original plaintext
+	decrypted, err := encKeypair.DecryptForSelf(nonce, ciphertext)
+	if err != nil {
+		t.Fatalf("Decryption failed: %v", err)
+	}
+
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Error("Decrypted data should match original plaintext")
+	}
+}
+
+func TestEncryptionDeterministic(t *testing.T) {
+	// Same key should produce different ciphertext each time (random nonce)
+	soul := NativeSoulCustom(stashHW1, "alice")
+	signingKeypair := DeriveKeypair(soul)
+	encKeypair := DeriveEncryptionKeys(signingKeypair.PrivateKey)
+
+	plaintext := []byte("same data")
+
+	nonce1, ciphertext1, _ := encKeypair.EncryptForSelf(plaintext)
+	nonce2, ciphertext2, _ := encKeypair.EncryptForSelf(plaintext)
+
+	// Nonces should be different
+	if bytes.Equal(nonce1, nonce2) {
+		t.Error("Each encryption should use a different random nonce")
+	}
+
+	// Ciphertexts should be different
+	if bytes.Equal(ciphertext1, ciphertext2) {
+		t.Error("Different nonces should produce different ciphertexts")
+	}
+
+	// But both should decrypt to the same plaintext
+	decrypted1, _ := encKeypair.DecryptForSelf(nonce1, ciphertext1)
+	decrypted2, _ := encKeypair.DecryptForSelf(nonce2, ciphertext2)
+
+	if !bytes.Equal(decrypted1, decrypted2) {
+		t.Error("Both should decrypt to same plaintext")
+	}
+}
+
+func TestDecryptWithWrongKey(t *testing.T) {
+	// Encrypt with one key, try to decrypt with another
+	soul1 := NativeSoulCustom(stashHW1, "alice")
+	soul2 := NativeSoulCustom(stashHW2, "bob")
+
+	encKeypair1 := DeriveEncryptionKeys(DeriveKeypair(soul1).PrivateKey)
+	encKeypair2 := DeriveEncryptionKeys(DeriveKeypair(soul2).PrivateKey)
+
+	plaintext := []byte("secret data")
+	nonce, ciphertext, _ := encKeypair1.EncryptForSelf(plaintext)
+
+	// Decrypting with wrong key should fail
+	_, err := encKeypair2.DecryptForSelf(nonce, ciphertext)
+	if err == nil {
+		t.Error("Decryption with wrong key should fail")
+	}
+}
+
+// =====================================================
+// Serialization Tests
+// =====================================================
+
+func TestStashDataSerialization(t *testing.T) {
+	// Create StashData
+	data := &StashData{
+		Timestamp: time.Now().Unix(),
+		Emojis:    []string{"🌸", "🦋", "🌊", "🔥", "⭐"},
+	}
+
+	// Serialize
+	serialized, err := data.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Deserialize
+	parsed := &StashData{}
+	err = parsed.Unmarshal(serialized)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	// Should match
+	if parsed.Timestamp != data.Timestamp {
+		t.Error("Timestamp mismatch after serialization")
+	}
+	if len(parsed.Emojis) != len(data.Emojis) {
+		t.Error("Emojis length mismatch after serialization")
+	}
+	for i, e := range data.Emojis {
+		if parsed.Emojis[i] != e {
+			t.Errorf("Emoji mismatch at %d: expected %s, got %s", i, e, parsed.Emojis[i])
+		}
+	}
+}
+
+func TestStashDataTimestampPreserved(t *testing.T) {
+	// The timestamp must survive full encrypt/decrypt cycle
+	soul := NativeSoulCustom(stashHW1, "alice")
+	encKeypair := DeriveEncryptionKeys(DeriveKeypair(soul).PrivateKey)
+
+	originalTimestamp := int64(1234567890)
+	data := &StashData{
+		Timestamp: originalTimestamp,
+		Emojis:    []string{"🌸", "🦋", "🌊"},
+	}
+
+	// Serialize, encrypt, decrypt, deserialize
+	serialized, _ := data.Marshal()
+	nonce, ciphertext, _ := encKeypair.EncryptForSelf(serialized)
+	decrypted, _ := encKeypair.DecryptForSelf(nonce, ciphertext)
+
+	parsed := &StashData{}
+	parsed.Unmarshal(decrypted)
+
+	if parsed.Timestamp != originalTimestamp {
+		t.Errorf("Timestamp not preserved: expected %d, got %d", originalTimestamp, parsed.Timestamp)
+	}
+}
+
+func TestGenerateRandomEmojis(t *testing.T) {
+	emojis := GenerateRandomEmojis(10)
+
+	if len(emojis) != 10 {
+		t.Errorf("Expected 10 emojis, got %d", len(emojis))
+	}
+
+	// All emojis should be from the pool
+	poolSet := make(map[string]bool)
+	for _, e := range EmojiPool {
+		poolSet[e] = true
+	}
+	for _, e := range emojis {
+		if !poolSet[e] {
+			t.Errorf("Emoji %s not in pool", e)
+		}
+	}
+
+	// Generate again - should be different (probabilistically)
+	emojis2 := GenerateRandomEmojis(10)
+	same := true
+	for i := range emojis {
+		if emojis[i] != emojis2[i] {
+			same = false
+			break
+		}
+	}
+	// Very unlikely to be the same (1 in 50^10)
+	if same {
+		t.Log("Warning: two random emoji sequences were identical (extremely unlikely)")
+	}
+}
+
+func TestEmojiPoolSize(t *testing.T) {
+	// Emoji pool should have enough variety
+	if len(EmojiPool) < 40 {
+		t.Errorf("Emoji pool too small: %d (expected at least 40)", len(EmojiPool))
+	}
+}
+
+// =====================================================
+// Confident Management Tests
+// =====================================================
+
+func TestConfidentTrackerAddRemove(t *testing.T) {
+	tracker := NewConfidentTracker(3)
+
+	// Add some confidents
+	tracker.Add("bob", time.Now().Unix())
+	tracker.Add("carol", time.Now().Unix())
+
+	if tracker.Count() != 2 {
+		t.Errorf("Expected 2 confidents, got %d", tracker.Count())
+	}
+
+	// Check if bob is tracked
+	if !tracker.Has("bob") {
+		t.Error("Should have bob")
+	}
+
+	// Remove bob
+	tracker.Remove("bob")
+	if tracker.Has("bob") {
+		t.Error("Should not have bob after removal")
+	}
+	if tracker.Count() != 1 {
+		t.Errorf("Expected 1 confident after removal, got %d", tracker.Count())
+	}
+}
+
+func TestConfidentTrackerTargetCount(t *testing.T) {
+	tracker := NewConfidentTracker(2)
+
+	// Add up to target
+	tracker.Add("bob", time.Now().Unix())
+	tracker.Add("carol", time.Now().Unix())
+
+	if !tracker.IsSatisfied() {
+		t.Error("Should be satisfied at target count")
+	}
+
+	// Add one more (over target)
+	tracker.Add("dave", time.Now().Unix())
+
+	if tracker.NeedsMore() {
+		t.Error("Should not need more when at target")
+	}
+
+	// Get excess confidents
+	excess := tracker.GetExcess()
+	if len(excess) != 1 {
+		t.Errorf("Expected 1 excess confident, got %d", len(excess))
+	}
+}
+
+func TestRandomConfidentSelection(t *testing.T) {
+	tracker := NewConfidentTracker(2)
+	tracker.Add("bob", time.Now().Unix())
+
+	online := []string{"alice", "bob", "carol", "dave", "eve"}
+
+	// Select should not return self or existing confidents
+	selected := tracker.SelectRandom("alice", online)
+	if selected == "" {
+		t.Error("Should select a confident")
+	}
+	if selected == "alice" {
+		t.Error("Should not select self")
+	}
+	if selected == "bob" {
+		t.Error("Should not select existing confident")
+	}
+
+	// With repeated calls, should get distribution
+	counts := make(map[string]int)
+	for i := 0; i < 1000; i++ {
+		s := tracker.SelectRandom("alice", online)
+		counts[s]++
+	}
+
+	// carol, dave, eve should all be selected (not alice or bob)
+	if counts["carol"] == 0 || counts["dave"] == 0 || counts["eve"] == 0 {
+		t.Error("Selection should be distributed among eligible candidates")
+	}
+	if counts["alice"] > 0 || counts["bob"] > 0 {
+		t.Error("Selection should exclude self and existing confidents")
+	}
+}
+
+func TestConfidentSelectionExcludesExisting(t *testing.T) {
+	tracker := NewConfidentTracker(3)
+	tracker.Add("bob", time.Now().Unix())
+	tracker.Add("carol", time.Now().Unix())
+
+	online := []string{"alice", "bob", "carol", "dave"}
+
+	// Only dave should be selectable
+	selected := tracker.SelectRandom("alice", online)
+	if selected != "dave" {
+		t.Errorf("Expected dave (only eligible), got %s", selected)
+	}
+
+	// If no one is eligible, return empty
+	tracker.Add("dave", time.Now().Unix())
+	selected = tracker.SelectRandom("alice", online)
+	if selected != "" {
+		t.Errorf("Expected empty (no eligible), got %s", selected)
+	}
+}
+
+// =====================================================
+// Message Tests
+// =====================================================
+
+func TestStashPayloadTimestamp(t *testing.T) {
+	// The timestamp is inside the encrypted payload
+	soul := NativeSoulCustom(stashHW1, "alice")
+	signingKeypair := DeriveKeypair(soul)
+	encKeypair := DeriveEncryptionKeys(signingKeypair.PrivateKey)
+
+	timestamp := time.Now().Unix()
+	stashData := &StashData{
+		Timestamp: timestamp,
+		Emojis:    []string{"🌸", "🦋", "🌊"},
+	}
+
+	// Create payload
+	payload, err := CreateStashPayload("alice", stashData, encKeypair)
+	if err != nil {
+		t.Fatalf("CreateStashPayload failed: %v", err)
+	}
+
+	// Extract timestamp (requires decryption)
+	extractedTimestamp, err := ExtractStashTimestamp(payload, encKeypair)
+	if err != nil {
+		t.Fatalf("ExtractStashTimestamp failed: %v", err)
+	}
+
+	if extractedTimestamp != timestamp {
+		t.Errorf("Timestamp mismatch: expected %d, got %d", timestamp, extractedTimestamp)
+	}
+}
+
+func TestSignatureVerification(t *testing.T) {
+	soul := NativeSoulCustom(stashHW1, "alice")
+	keypair := DeriveKeypair(soul)
+	encKeypair := DeriveEncryptionKeys(keypair.PrivateKey)
+
+	stashData := &StashData{
+		Timestamp: time.Now().Unix(),
+		Emojis:    []string{"🔥", "⭐"},
+	}
+	payload, _ := CreateStashPayload("alice", stashData, encKeypair)
+
+	// Create signed StashStore message
+	msg := &StashStore{
+		From:    "alice",
+		Payload: *payload,
+	}
+	msg.Sign(keypair)
+
+	// Should verify with correct public key
+	if !msg.Verify(keypair.PublicKey) {
+		t.Error("Valid signature should verify")
+	}
+
+	// Should not verify with wrong public key
+	otherKeypair := DeriveKeypair(NativeSoulCustom(stashHW2, "bob"))
+	if msg.Verify(otherKeypair.PublicKey) {
+		t.Error("Should not verify with wrong public key")
+	}
+
+	// Tampered message should not verify
+	msg.From = "mallory"
+	if msg.Verify(keypair.PublicKey) {
+		t.Error("Tampered message should not verify")
+	}
+}
+
+// =====================================================
+// Bootstrap Workflow Tests (Mock Network)
+// =====================================================
+
+func TestBootstrapNoStash(t *testing.T) {
+	// Nara boots, no one has their stash, should start fresh
+	network := NewMockMeshNetwork()
+
+	// Set up owner
+	ownerSoul := NativeSoulCustom(stashHW1, "alice")
+	ownerKeypair := DeriveKeypair(ownerSoul)
+
+	// Create stash manager for owner
+	manager := NewStashManager("alice", ownerKeypair, 2)
+
+	// Request stash (broadcast) - no one responds
+	responses := make(chan *StashResponse, 10)
+	go manager.RequestStash(network, responses)
+
+	// Wait a bit and close (simulating timeout)
+	time.Sleep(100 * time.Millisecond)
+	close(responses)
+
+	// Should have no recovered stash
+	if manager.HasRecoveredStash() {
+		t.Error("Should not have recovered stash when no one responds")
+	}
+
+	// Should be ready for fresh start
+	if !manager.ShouldStartFresh() {
+		t.Error("Should be ready for fresh start")
+	}
+}
+
+func TestBootstrapWithStash(t *testing.T) {
+	// Nara boots, requests stash, receives from confident, recovers emojis
+	network := NewMockMeshNetwork()
+
+	// Set up owner
+	ownerSoul := NativeSoulCustom(stashHW1, "alice")
+	ownerKeypair := DeriveKeypair(ownerSoul)
+	ownerEncKeypair := DeriveEncryptionKeys(ownerKeypair.PrivateKey)
+
+	// Create stash data with emojis
+	originalEmojis := []string{"🌸", "🦋", "🌊", "🔥", "⭐"}
+	originalTimestamp := time.Now().Unix() - 3600 // 1 hour ago
+	stashData := &StashData{
+		Timestamp: originalTimestamp,
+		Emojis:    originalEmojis,
+	}
+	payload, _ := CreateStashPayload("alice", stashData, ownerEncKeypair)
+
+	// Set up confident (bob) who has alice's stash
+	bobTransport := NewMockMeshTransport()
+	network.Register("bob", bobTransport)
+
+	// Create manager and simulate recovery
+	manager := NewStashManager("alice", ownerKeypair, 2)
+
+	// Simulate receiving response from bob
+	responses := make(chan *StashResponse, 10)
+	responses <- &StashResponse{
+		From:    "bob",
+		Owner:   "alice",
+		Payload: *payload,
+	}
+	close(responses)
+
+	// Process responses
+	err := manager.ProcessResponses(responses)
+	if err != nil {
+		t.Fatalf("ProcessResponses failed: %v", err)
+	}
+
+	// Should have recovered stash
+	if !manager.HasRecoveredStash() {
+		t.Error("Should have recovered stash")
+	}
+
+	// Verify recovered emojis
+	recoveredEmojis := manager.GetRecoveredEmojis()
+	if len(recoveredEmojis) != len(originalEmojis) {
+		t.Errorf("Emoji count mismatch: expected %d, got %d", len(originalEmojis), len(recoveredEmojis))
+	}
+	for i, e := range originalEmojis {
+		if recoveredEmojis[i] != e {
+			t.Errorf("Emoji mismatch at %d: expected %s, got %s", i, e, recoveredEmojis[i])
+		}
+	}
+
+	// Verify timestamp
+	if manager.GetRecoveredTimestamp() != originalTimestamp {
+		t.Errorf("Timestamp mismatch: expected %d, got %d", originalTimestamp, manager.GetRecoveredTimestamp())
+	}
+}
+
+func TestBootstrapMultipleResponses(t *testing.T) {
+	// Multiple confidents respond, pick newest timestamp
+	ownerSoul := NativeSoulCustom(stashHW1, "alice")
+	ownerKeypair := DeriveKeypair(ownerSoul)
+	ownerEncKeypair := DeriveEncryptionKeys(ownerKeypair.PrivateKey)
+
+	now := time.Now().Unix()
+
+	// Create older stash (from bob)
+	olderData := &StashData{
+		Timestamp: now - 3600, // 1 hour ago
+		Emojis:    []string{"🌳", "🌲"},
+	}
+	olderPayload, _ := CreateStashPayload("alice", olderData, ownerEncKeypair)
+
+	// Create newer stash (from carol)
+	newerData := &StashData{
+		Timestamp: now - 60, // 1 minute ago
+		Emojis:    []string{"🌴", "🌵", "🌾"},
+	}
+	newerPayload, _ := CreateStashPayload("alice", newerData, ownerEncKeypair)
+
+	// Create manager
+	manager := NewStashManager("alice", ownerKeypair, 2)
+
+	// Simulate receiving both responses (older first)
+	responses := make(chan *StashResponse, 10)
+	responses <- &StashResponse{From: "bob", Owner: "alice", Payload: *olderPayload}
+	responses <- &StashResponse{From: "carol", Owner: "alice", Payload: *newerPayload}
+	close(responses)
+
+	// Process - should pick newest
+	manager.ProcessResponses(responses)
+
+	// The recovered data should be the newer one
+	recoveredTimestamp := manager.GetRecoveredTimestamp()
+	if recoveredTimestamp != now-60 {
+		t.Errorf("Should pick newest stash, expected %d, got %d", now-60, recoveredTimestamp)
+	}
+}
+
+func TestBootstrapStaleStash(t *testing.T) {
+	// Reject stash with timestamp older than what we already have
+	ownerSoul := NativeSoulCustom(stashHW1, "alice")
+	ownerKeypair := DeriveKeypair(ownerSoul)
+	ownerEncKeypair := DeriveEncryptionKeys(ownerKeypair.PrivateKey)
+
+	now := time.Now().Unix()
+
+	// Manager already has a stash with a recent timestamp
+	manager := NewStashManager("alice", ownerKeypair, 2)
+	manager.SetCurrentTimestamp(now - 60) // 1 minute ago
+
+	// Receive older stash
+	staleData := &StashData{
+		Timestamp: now - 3600, // 1 hour ago (stale!)
+		Emojis:    []string{"🍄", "🪨"},
+	}
+	stalePayload, _ := CreateStashPayload("alice", staleData, ownerEncKeypair)
+
+	responses := make(chan *StashResponse, 10)
+	responses <- &StashResponse{From: "bob", Owner: "alice", Payload: *stalePayload}
+	close(responses)
+
+	// Process - should reject stale
+	manager.ProcessResponses(responses)
+
+	// Should NOT have updated with stale data
+	if manager.GetRecoveredTimestamp() == now-3600 {
+		t.Error("Should reject stale stash")
+	}
+}
+
+// =====================================================
+// Runtime Workflow Tests (Mock Network)
+// =====================================================
+
+func TestStashStoreAndAck(t *testing.T) {
+	// Owner sends StashStore, confident stores and acks
+	network := NewMockMeshNetwork()
+
+	// Set up confident (bob)
+	bobTransport := NewMockMeshTransport()
+	network.Register("bob", bobTransport)
+	bobManager := NewConfidentStashStore() // in-memory store for confidents
+
+	// Set up owner (alice)
+	aliceSoul := NativeSoulCustom(stashHW1, "alice")
+	aliceKeypair := DeriveKeypair(aliceSoul)
+	aliceEncKeypair := DeriveEncryptionKeys(aliceKeypair.PrivateKey)
+
+	// Create stash
+	stashData := &StashData{
+		Timestamp: time.Now().Unix(),
+		Emojis:    []string{"🦋", "🐝", "🐛"},
+	}
+	payload, _ := CreateStashPayload("alice", stashData, aliceEncKeypair)
+
+	// Create signed store message
+	storeMsg := &StashStore{
+		From:    "alice",
+		Payload: *payload,
+	}
+	storeMsg.Sign(aliceKeypair)
+
+	// Bob receives and processes
+	err := bobManager.HandleStashStore(storeMsg, func(name string) []byte {
+		if name == "alice" {
+			return aliceKeypair.PublicKey
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("HandleStashStore failed: %v", err)
+	}
+
+	// Bob should have stored it
+	if !bobManager.HasStashFor("alice") {
+		t.Error("Bob should have stored alice's stash")
+	}
+
+	// Bob should send ack
+	ack := bobManager.CreateAck("alice")
+	if ack.Owner != "alice" {
+		t.Error("Ack should be for alice")
+	}
+}
+
+func TestStashRequestTriggersResponse(t *testing.T) {
+	// Broadcast request, confident sends payload
+	bobManager := NewConfidentStashStore()
+
+	// Pre-store alice's stash in bob
+	aliceSoul := NativeSoulCustom(stashHW1, "alice")
+	aliceKeypair := DeriveKeypair(aliceSoul)
+	aliceEncKeypair := DeriveEncryptionKeys(aliceKeypair.PrivateKey)
+
+	stashData := &StashData{
+		Timestamp: time.Now().Unix(),
+		Emojis:    []string{"🦎", "🐢"},
+	}
+	payload, _ := CreateStashPayload("alice", stashData, aliceEncKeypair)
+	bobManager.Store("alice", payload)
+
+	// Alice sends request
+	request := &StashRequest{
+		From: "alice",
+	}
+	request.Sign(aliceKeypair)
+
+	// Bob handles request
+	response := bobManager.HandleStashRequest(request, func(name string) []byte {
+		if name == "alice" {
+			return aliceKeypair.PublicKey
+		}
+		return nil
+	})
+
+	// Should return the stored stash
+	if response == nil {
+		t.Fatal("Bob should respond with stored stash")
+	}
+	if response.Owner != "alice" {
+		t.Error("Response should be for alice")
+	}
+}
+
+func TestStashDelete(t *testing.T) {
+	// Owner asks confident to delete, confident removes from memory
+	bobManager := NewConfidentStashStore()
+
+	// Pre-store alice's stash
+	aliceSoul := NativeSoulCustom(stashHW1, "alice")
+	aliceKeypair := DeriveKeypair(aliceSoul)
+	aliceEncKeypair := DeriveEncryptionKeys(aliceKeypair.PrivateKey)
+
+	payload, _ := CreateStashPayload("alice", &StashData{
+		Timestamp: time.Now().Unix(),
+		Emojis:    []string{"🔥", "⭐"},
+	}, aliceEncKeypair)
+	bobManager.Store("alice", payload)
+
+	if !bobManager.HasStashFor("alice") {
+		t.Fatal("Setup: bob should have alice's stash")
+	}
+
+	// Alice sends delete request
+	deleteMsg := &StashDelete{
+		From: "alice",
+	}
+	deleteMsg.Sign(aliceKeypair)
+
+	// Bob handles delete
+	err := bobManager.HandleStashDelete(deleteMsg, func(name string) []byte {
+		if name == "alice" {
+			return aliceKeypair.PublicKey
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("HandleStashDelete failed: %v", err)
+	}
+
+	// Bob should no longer have alice's stash
+	if bobManager.HasStashFor("alice") {
+		t.Error("Bob should have deleted alice's stash")
+	}
+}
+
+func TestConfidentGoesOffline(t *testing.T) {
+	// Confident disappears, owner picks new random one
+	tracker := NewConfidentTracker(2)
+	tracker.Add("bob", time.Now().Unix())
+	tracker.Add("carol", time.Now().Unix())
+
+	online := []string{"alice", "carol", "dave"} // bob is offline
+
+	// Mark bob as gone
+	tracker.MarkOffline("bob", online)
+
+	// Bob should be removed
+	if tracker.Has("bob") {
+		t.Error("Offline confident should be removed")
+	}
+
+	// Should need to pick a replacement
+	if !tracker.NeedsMore() {
+		t.Error("Should need replacement confident")
+	}
+
+	// Pick new one
+	selected := tracker.SelectRandom("alice", online)
+	if selected != "dave" {
+		t.Errorf("Should select dave as replacement, got %s", selected)
+	}
+}
+
+func TestTooManyConfidents(t *testing.T) {
+	// >3 confidents, owner asks extras to delete
+	tracker := NewConfidentTracker(2) // target: 2
+
+	tracker.Add("bob", time.Now().Unix())
+	tracker.Add("carol", time.Now().Unix())
+	tracker.Add("dave", time.Now().Unix())
+	tracker.Add("eve", time.Now().Unix())
+
+	// Should have excess
+	excess := tracker.GetExcess()
+	if len(excess) != 2 {
+		t.Errorf("Expected 2 excess confidents, got %d", len(excess))
+	}
+}
+
+func TestCloutRewardForStoring(t *testing.T) {
+	// Confident gets clout when storing stash
+	personality := NaraPersonality{Sociability: 50, Agreeableness: 50, Chill: 50}
+	ledger := NewSyncLedger(1000)
+	cloutProjection := NewCloutProjection(ledger)
+
+	// Record stash stored event
+	event := SyncEvent{
+		Timestamp: time.Now().Unix(),
+		Service:   ServiceSocial,
+		Social: &SocialEventPayload{
+			Type:   "service", // service events always give positive clout
+			Actor:  "bob",
+			Target: "alice",
+			Reason: ReasonStashStored,
+		},
+	}
+	event.ComputeID()
+
+	added := ledger.AddEvent(event)
+	if !added {
+		t.Error("Should add stash stored event")
+	}
+
+	// Process events before querying
+	cloutProjection.RunToEnd(context.Background())
+
+	// Bob should gain clout
+	clout := cloutProjection.DeriveClout("observer-soul", personality)
+	if clout["bob"] <= 0 {
+		t.Error("Bob should gain clout for storing stash")
+	}
+}
+
+// =====================================================
+// Size Limit Tests
+// =====================================================
+
+func TestStashSizeLimit(t *testing.T) {
+	// Stash should be limited to 10KB
+	manager := NewConfidentStashStore()
+
+	// Create oversized payload
+	largePayload := &StashPayload{
+		Owner:      "alice",
+		Nonce:      make([]byte, 24),
+		Ciphertext: make([]byte, 20*1024), // 20KB - too large
+	}
+
+	aliceSoul := NativeSoulCustom(stashHW1, "alice")
+	aliceKeypair := DeriveKeypair(aliceSoul)
+
+	storeMsg := &StashStore{
+		From:    "alice",
+		Payload: *largePayload,
+	}
+	storeMsg.Sign(aliceKeypair)
+
+	err := manager.HandleStashStore(storeMsg, func(name string) []byte {
+		return aliceKeypair.PublicKey
+	})
+
+	if err == nil {
+		t.Error("Should reject oversized stash")
+	}
+}
+
+// =====================================================
+// Integration Tests
+// =====================================================
+
+func TestEndToEndStashFlow(t *testing.T) {
+	// Full end-to-end flow: create emojis, stash to confidents, recover from scratch
+
+	// Setup: Create owner (alice) with emoji identity
+	aliceSoul := NativeSoulCustom(stashHW1, "alice")
+	aliceKeypair := DeriveKeypair(aliceSoul)
+	aliceEncKeypair := DeriveEncryptionKeys(aliceKeypair.PrivateKey)
+
+	// Create stash data with emojis
+	originalEmojis := []string{"🌸", "🦋", "🌊", "🔥", "⭐", "🌙", "🌈", "⚡", "❄️", "🍄"}
+	timestamp := time.Now().Unix() - 86400 // 1 day ago
+	stashData := &StashData{
+		Timestamp: timestamp,
+		Emojis:    originalEmojis,
+	}
+	payload, err := CreateStashPayload("alice", stashData, aliceEncKeypair)
+	if err != nil {
+		t.Fatalf("CreateStashPayload failed: %v", err)
+	}
+
+	// Setup: Two confidents (bob and carol)
+	bobStore := NewConfidentStashStore()
+	carolStore := NewConfidentStashStore()
+
+	getPublicKey := func(name string) []byte {
+		if name == "alice" {
+			return aliceKeypair.PublicKey
+		}
+		return nil
+	}
+
+	// Phase 1: Alice stores stash with confidents
+	storeMsg := &StashStore{
+		From:    "alice",
+		Payload: *payload,
+	}
+	storeMsg.Sign(aliceKeypair)
+
+	err = bobStore.HandleStashStore(storeMsg, getPublicKey)
+	if err != nil {
+		t.Fatalf("Bob store failed: %v", err)
+	}
+	err = carolStore.HandleStashStore(storeMsg, getPublicKey)
+	if err != nil {
+		t.Fatalf("Carol store failed: %v", err)
+	}
+
+	// Verify both confidents have the stash
+	if !bobStore.HasStashFor("alice") || !carolStore.HasStashFor("alice") {
+		t.Error("Confidents should have alice's stash")
+	}
+
+	// Phase 2: Alice "reboots" (loses state) and requests stash
+	request := &StashRequest{From: "alice"}
+	request.Sign(aliceKeypair)
+
+	// Confidents respond
+	bobResponse := bobStore.HandleStashRequest(request, getPublicKey)
+	carolResponse := carolStore.HandleStashRequest(request, getPublicKey)
+
+	if bobResponse == nil || carolResponse == nil {
+		t.Fatal("Confidents should respond to request")
+	}
+
+	// Phase 3: Alice recovers state
+	recoveryManager := NewStashManager("alice", aliceKeypair, 2)
+
+	responses := make(chan *StashResponse, 10)
+	responses <- bobResponse
+	responses <- carolResponse
+	close(responses)
+
+	err = recoveryManager.ProcessResponses(responses)
+	if err != nil {
+		t.Fatalf("ProcessResponses failed: %v", err)
+	}
+
+	if !recoveryManager.HasRecoveredStash() {
+		t.Fatal("Should have recovered stash")
+	}
+
+	// Verify recovered emojis match original
+	recoveredEmojis := recoveryManager.GetRecoveredEmojis()
+	if len(recoveredEmojis) != len(originalEmojis) {
+		t.Errorf("Emoji count mismatch: expected %d, got %d", len(originalEmojis), len(recoveredEmojis))
+	}
+	for i, e := range originalEmojis {
+		if recoveredEmojis[i] != e {
+			t.Errorf("Emoji mismatch at %d: expected %s, got %s", i, e, recoveredEmojis[i])
+		}
+	}
+
+	// Verify timestamp matches
+	if recoveryManager.GetRecoveredTimestamp() != timestamp {
+		t.Errorf("Timestamp mismatch: expected %d, got %d", timestamp, recoveryManager.GetRecoveredTimestamp())
+	}
+
+	t.Log("End-to-end stash flow completed successfully")
+}
+
+func TestConfidentTrackerWithMockNetwork(t *testing.T) {
+	// Test confident management with simulated network churn
+
+	tracker := NewConfidentTracker(2)
+	online := []string{"alice", "bob", "carol", "dave", "eve"}
+
+	// Alice picks initial confidents
+	conf1 := tracker.SelectRandom("alice", online)
+	if conf1 == "" {
+		t.Fatal("Should select first confident")
+	}
+	tracker.Add(conf1, time.Now().Unix())
+
+	conf2 := tracker.SelectRandom("alice", online)
+	if conf2 == "" || conf2 == conf1 {
+		t.Fatal("Should select different second confident")
+	}
+	tracker.Add(conf2, time.Now().Unix())
+
+	// Should be satisfied
+	if !tracker.IsSatisfied() {
+		t.Error("Should be satisfied with 2 confidents")
+	}
+
+	// Simulate one going offline
+	newOnline := []string{"alice", "bob", "dave"} // carol and eve offline
+	tracker.MarkOffline(conf1, newOnline)
+	tracker.MarkOffline(conf2, newOnline)
+
+	// Check if we need replacements
+	if tracker.IsSatisfied() {
+		// Might still be satisfied if both conf1 and conf2 are in newOnline
+		t.Log("Still satisfied after network churn")
+	} else {
+		// Need to pick new confidents
+		newConf := tracker.SelectRandom("alice", newOnline)
+		if newConf != "" {
+			tracker.Add(newConf, time.Now().Unix())
+		}
+	}
+
+	t.Logf("Final confident count: %d", tracker.Count())
+}
+
+func TestConcurrentStashRequests(t *testing.T) {
+	// Test handling multiple simultaneous stash requests
+
+	// Setup one confident with alice's stash
+	confidentStore := NewConfidentStashStore()
+
+	aliceSoul := NativeSoulCustom(stashHW1, "alice")
+	aliceKeypair := DeriveKeypair(aliceSoul)
+	aliceEncKeypair := DeriveEncryptionKeys(aliceKeypair.PrivateKey)
+
+	stashData := &StashData{
+		Timestamp: time.Now().Unix(),
+		Emojis:    []string{"🐙", "🦑", "🦀"},
+	}
+	payload, _ := CreateStashPayload("alice", stashData, aliceEncKeypair)
+
+	storeMsg := &StashStore{From: "alice", Payload: *payload}
+	storeMsg.Sign(aliceKeypair)
+	confidentStore.HandleStashStore(storeMsg, func(name string) []byte {
+		if name == "alice" {
+			return aliceKeypair.PublicKey
+		}
+		return nil
+	})
+
+	// Simulate concurrent requests
+	results := make(chan *StashResponse, 10)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			request := &StashRequest{From: "alice"}
+			request.Sign(aliceKeypair)
+			response := confidentStore.HandleStashRequest(request, func(name string) []byte {
+				if name == "alice" {
+					return aliceKeypair.PublicKey
+				}
+				return nil
+			})
+			if response != nil {
+				results <- response
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	// All requests should have gotten responses
+	responseCount := 0
+	for range results {
+		responseCount++
+	}
+
+	if responseCount != 10 {
+		t.Errorf("Expected 10 responses, got %d", responseCount)
+	}
+}
+
+func TestStashTimestampConflictResolution(t *testing.T) {
+	// Test that newest timestamp wins when multiple responses arrive
+
+	aliceSoul := NativeSoulCustom(stashHW1, "alice")
+	aliceKeypair := DeriveKeypair(aliceSoul)
+	aliceEncKeypair := DeriveEncryptionKeys(aliceKeypair.PrivateKey)
+
+	now := time.Now().Unix()
+
+	// Create three stashes with different timestamps
+	stashes := []struct {
+		from      string
+		timestamp int64
+		emojis    []string
+	}{
+		{"bob", now - 3600, []string{"🌸", "🦋"}},  // 1 hour ago
+		{"carol", now - 60, []string{"🌊", "🔥"}},  // 1 minute ago
+		{"dave", now - 1800, []string{"⭐", "🌙"}}, // 30 minutes ago
+	}
+
+	responses := make(chan *StashResponse, 10)
+	for _, s := range stashes {
+		data := &StashData{
+			Timestamp: s.timestamp,
+			Emojis:    s.emojis,
+		}
+		payload, _ := CreateStashPayload("alice", data, aliceEncKeypair)
+		responses <- &StashResponse{
+			From:    s.from,
+			Owner:   "alice",
+			Payload: *payload,
+		}
+	}
+	close(responses)
+
+	manager := NewStashManager("alice", aliceKeypair, 2)
+	manager.ProcessResponses(responses)
+
+	// Should have picked carol's (newest)
+	recoveredTimestamp := manager.GetRecoveredTimestamp()
+	if recoveredTimestamp != now-60 {
+		t.Errorf("Should pick newest timestamp (carol's), got timestamp from %ds ago", now-recoveredTimestamp)
+	}
+}

--- a/stash_test.go
+++ b/stash_test.go
@@ -883,19 +883,22 @@ func TestCloutRewardForStoring(t *testing.T) {
 	cloutProjection := NewCloutProjection(ledger)
 
 	// Record stash stored event
-	event := SyncEvent{
-		Timestamp: time.Now().Unix(),
-		Service:   ServiceSocial,
-		Social: &SocialEventPayload{
-			Type:   "service", // service events always give positive clout
-			Actor:  "bob",
-			Target: "alice",
-			Reason: ReasonStashStored,
-		},
+	event := SocialEventPayload{
+		Type:   "service", // service events always give positive clout
+		Actor:  "bob",
+		Target: "alice",
+		Reason: ReasonStashStored,
 	}
-	event.ComputeID()
 
-	added := ledger.AddEvent(event)
+	syncEvent := SyncEvent{
+		Service:   ServiceSocial,
+		Timestamp: time.Now().UnixNano(),
+		Emitter:   "bob",
+		Social:    &event,
+	}
+	syncEvent.ComputeID()
+
+	added := ledger.AddEvent(syncEvent)
 	if !added {
 		t.Error("Should add stash stored event")
 	}
@@ -906,7 +909,7 @@ func TestCloutRewardForStoring(t *testing.T) {
 	// Bob should gain clout
 	clout := cloutProjection.DeriveClout("observer-soul", personality)
 	if clout["bob"] <= 0 {
-		t.Error("Bob should gain clout for storing stash")
+		t.Errorf("Bob should gain clout for storing stash, got %f", clout["bob"])
 	}
 }
 

--- a/sync.go
+++ b/sync.go
@@ -127,7 +127,7 @@ func (p *SocialEventPayload) ContentString() string {
 // IsValid checks if the payload is well-formed
 func (p *SocialEventPayload) IsValid() bool {
 	validTypes := map[string]bool{
-		"tease": true, "observed": true, "gossip": true, "observation": true,
+		"tease": true, "observed": true, "gossip": true, "observation": true, "service": true,
 	}
 	return validTypes[p.Type] && p.Actor != "" && p.Target != ""
 }


### PR DESCRIPTION
This pull request introduces a distributed, encrypted, memory-only storage system called "Stash" for naras, allowing them to securely store and recover arbitrary JSON state across the network without relying on local disk. The implementation includes both code and documentation, covering the commitment model, encryption, endpoints, metrics, and integration with the existing gossip/sync system. It also adds new cryptographic primitives for self-encryption using XChaCha20-Poly1305 and HKDF. Documentation and settings are updated to reflect these changes.

**Major features and changes:**

### 1. Stash Distributed Encrypted Storage (Documentation & Design)
- Added `STASH.md` with a comprehensive design doc for the stash system, detailing the commitment model, HTTP endpoints, encryption scheme, memory-aware capacity management, health monitoring, metrics, and Web UI integration.
- Updated `AGENTS.md` and `SYNC.md` to document the stash system, its role, endpoints, event types, and integration with the distributed sync/gossip protocol. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L54-R61) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R114) [[3]](diffhunk://#diff-3d99e517d949327c5f8ff76084a636433efa693d73b43f35d10bf17f96808e02R48-R50) [[4]](diffhunk://#diff-3d99e517d949327c5f8ff76084a636433efa693d73b43f35d10bf17f96808e02R102-R142) [[5]](diffhunk://#diff-3d99e517d949327c5f8ff76084a636433efa693d73b43f35d10bf17f96808e02R211-R231)

### 2. Cryptographic Primitives for Stash Encryption
- Implemented new functions in `crypto.go` for deriving a symmetric encryption key from an Ed25519 private key using HKDF, and for encrypting/decrypting data with XChaCha20-Poly1305 (self-encryption for stash). [[1]](diffhunk://#diff-69c5c48c1da9bf0e59ac32c7d0c0089fee30329073ffcc86cf7200f224f44ecfR5-R13) [[2]](diffhunk://#diff-69c5c48c1da9bf0e59ac32c7d0c0089fee30329073ffcc86cf7200f224f44ecfR87-R153)

### 3. Stash Metrics and Social Events
- Added new fields to status broadcasts and metrics: number of stashes stored for others, total stash bytes, and number of confidants. Social events now include "stash_stored" for rewarding helpful storage. [[1]](diffhunk://#diff-3d99e517d949327c5f8ff76084a636433efa693d73b43f35d10bf17f96808e02R211-R231) [[2]](diffhunk://#diff-3d99e517d949327c5f8ff76084a636433efa693d73b43f35d10bf17f96808e02R48-R50)

These changes collectively enable secure, ephemeral, distributed state storage and recovery for naras, with strong guarantees around privacy, durability (via mutual commitments), and operational transparency.so it can withstand reboots