### PR TITLE
checkpoints v2

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,8 @@
       "Bash(/usr/bin/make:*)",
       "Bash(npm run build:*)",
       "Bash(gofmt:*)",
-      "Bash(golangci-lint run:*)"
+      "Bash(golangci-lint run:*)",
+      "Bash(find:*)"
     ]
   }
 }

--- a/checkpoint_service.go
+++ b/checkpoint_service.go
@@ -240,9 +240,12 @@ func (s *CheckpointService) proposeCheckpointRound(round int, consensusValues *r
 
 	now := time.Now().Unix()
 
+	// v2: Get reference point - the last checkpoint we've seen for ourselves
+	lastSeenCheckpointID := s.ledger.GetLatestCheckpointID(myName)
+
 	// Create attestation (self-attestation: I claim this about myself)
 	attestation := Attestation{
-		Version:   1, // Attestation format version
+		Version:   2, // v2: includes reference point
 		Subject:   myName,
 		SubjectID: myID,
 		Observation: NaraObservation{
@@ -250,9 +253,10 @@ func (s *CheckpointService) proposeCheckpointRound(round int, consensusValues *r
 			TotalUptime: totalUptime,
 			StartTime:   firstSeen,
 		},
-		Attester:   myName, // Same as Subject for self-attestation
-		AttesterID: myID,   // Same as SubjectID for self-attestation
-		AsOfTime:   now,
+		Attester:             myName, // Same as Subject for self-attestation
+		AttesterID:           myID,   // Same as SubjectID for self-attestation
+		AsOfTime:             now,
+		LastSeenCheckpointID: lastSeenCheckpointID, // v2: reference point
 	}
 
 	// Sign the attestation
@@ -342,6 +346,9 @@ func (s *CheckpointService) HandleProposal(proposal *CheckpointProposal) {
 		s.valuesMatch(proposal.Observation.TotalUptime, ourUptime, 60) &&
 		s.valuesMatch(proposal.Observation.StartTime, ourFirstSeen, 60)
 
+	// v2: Get our reference point - the last checkpoint we've seen for the subject
+	lastSeenCheckpointID := s.ledger.GetLatestCheckpointID(proposal.Subject)
+
 	// Create attestation (third-party: I claim this about someone else)
 	var observation NaraObservation
 	if approved {
@@ -357,13 +364,14 @@ func (s *CheckpointService) HandleProposal(proposal *CheckpointProposal) {
 	}
 
 	attestation := Attestation{
-		Version:     1, // Attestation format version
-		Subject:     proposal.Subject,
-		SubjectID:   proposal.SubjectID,
-		Observation: observation,
-		Attester:    s.local.Me.Name,      // We are the attester (voter)
-		AttesterID:  s.local.Me.Status.ID, // Our ID
-		AsOfTime:    proposal.AsOfTime,    // Sign the SAME timestamp as proposal
+		Version:              2, // v2: includes reference point
+		Subject:              proposal.Subject,
+		SubjectID:            proposal.SubjectID,
+		Observation:          observation,
+		Attester:             s.local.Me.Name,      // We are the attester (voter)
+		AttesterID:           s.local.Me.Status.ID, // Our ID
+		AsOfTime:             proposal.AsOfTime,    // Sign the SAME timestamp as proposal
+		LastSeenCheckpointID: lastSeenCheckpointID, // v2: our reference point for this subject
 	}
 
 	// Sign the attestation
@@ -551,22 +559,33 @@ func (s *CheckpointService) tryFindConsensus(proposal *CheckpointProposal, votes
 		return nil, false
 	}
 
-	// Group votes by their signed values
+	// Group votes by their signed values (v2: includes reference point)
 	type valueKey struct {
-		Restarts    int64
-		TotalUptime int64
-		FirstSeen   int64
+		Restarts             int64
+		TotalUptime          int64
+		FirstSeen            int64
+		LastSeenCheckpointID string // v2: votes must agree on reference point
 	}
 
 	groups := make(map[valueKey][]*CheckpointVote)
 
 	for _, vote := range votes {
-		key := valueKey{vote.Observation.Restarts, vote.Observation.TotalUptime, vote.Observation.StartTime}
+		key := valueKey{
+			Restarts:             vote.Observation.Restarts,
+			TotalUptime:          vote.Observation.TotalUptime,
+			FirstSeen:            vote.Observation.StartTime,
+			LastSeenCheckpointID: vote.LastSeenCheckpointID,
+		}
 		groups[key] = append(groups[key], vote)
 	}
 
 	// Also add our own proposal values as a potential group
-	proposalKey := valueKey{proposal.Observation.Restarts, proposal.Observation.TotalUptime, proposal.Observation.StartTime}
+	proposalKey := valueKey{
+		Restarts:             proposal.Observation.Restarts,
+		TotalUptime:          proposal.Observation.TotalUptime,
+		FirstSeen:            proposal.Observation.StartTime,
+		LastSeenCheckpointID: proposal.LastSeenCheckpointID,
+	}
 
 	// Find the largest group that meets minimum threshold
 	var bestKey valueKey
@@ -611,9 +630,11 @@ func (s *CheckpointService) tryFindConsensus(proposal *CheckpointProposal, votes
 
 	// Build checkpoint with matching signatures
 	checkpoint := &CheckpointEventPayload{
-		Subject:   proposal.Subject,
-		SubjectID: proposal.SubjectID,
-		AsOfTime:  proposal.AsOfTime,
+		Version:              2, // v2: includes chain of trust
+		Subject:              proposal.Subject,
+		SubjectID:            proposal.SubjectID,
+		PreviousCheckpointID: bestKey.LastSeenCheckpointID, // v2: reference point from consensus
+		AsOfTime:             proposal.AsOfTime,
 		Observation: NaraObservation{
 			Restarts:    bestKey.Restarts,
 			TotalUptime: bestKey.TotalUptime,
@@ -628,7 +649,8 @@ func (s *CheckpointService) tryFindConsensus(proposal *CheckpointProposal, votes
 	proposerIncluded := false
 	if bestKey.Restarts == proposal.Observation.Restarts &&
 		bestKey.TotalUptime == proposal.Observation.TotalUptime &&
-		bestKey.FirstSeen == proposal.Observation.StartTime {
+		bestKey.FirstSeen == proposal.Observation.StartTime &&
+		bestKey.LastSeenCheckpointID == proposal.LastSeenCheckpointID {
 		checkpoint.VoterIDs = append(checkpoint.VoterIDs, proposal.SubjectID)
 		checkpoint.Signatures = append(checkpoint.Signatures, proposal.Signature)
 		proposerIncluded = true
@@ -695,11 +717,17 @@ func (s *CheckpointService) storeCheckpoint(checkpoint *CheckpointEventPayload) 
 	)
 
 	// Update with voter info and metadata
-	event.Checkpoint.Version = 1 // Checkpoint format version
+	event.Checkpoint.Version = 2 // v2: includes chain of trust
 	event.Checkpoint.VoterIDs = checkpoint.VoterIDs
 	event.Checkpoint.Signatures = checkpoint.Signatures
 	event.Checkpoint.SubjectID = checkpoint.SubjectID
 	event.Checkpoint.Round = checkpoint.Round
+
+	// v2: Set previous checkpoint ID for chain of trust
+	event.Checkpoint.PreviousCheckpointID = s.ledger.GetLatestCheckpointID(checkpoint.Subject)
+
+	// Recompute ID since PreviousCheckpointID affects ContentString
+	event.ComputeID()
 
 	// Verify at least MinCheckpointSignatures signatures before accepting
 	result := s.verifyCheckpointSignatures(event.Checkpoint)

--- a/checkpoint_v2_test.go
+++ b/checkpoint_v2_test.go
@@ -1,0 +1,475 @@
+package nara
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"testing"
+	"time"
+)
+
+// Helper to decode base64 public key
+func pubKeyFromBase64(encoded string) ed25519.PublicKey {
+	decoded, _ := base64.StdEncoding.DecodeString(encoded)
+	return ed25519.PublicKey(decoded)
+}
+
+// TestCheckpointV1BackwardsCompat tests that v1 checkpoints still verify correctly
+// This ensures we haven't broken existing checkpoint verification
+func TestCheckpointV1BackwardsCompat(t *testing.T) {
+	subject := "lisa"
+	subjectID := "lisa-id-abc"
+	voterIDs := []string{"homer-id", "marge-id", "bart-id"}
+	keypairs := make([]NaraKeypair, 3)
+	publicKeys := make(map[string]string)
+
+	for i, voterID := range voterIDs {
+		keypairs[i] = generateTestKeypair()
+		publicKeys[voterID] = pubKeyToBase64(keypairs[i].PublicKey)
+	}
+
+	// Create v1 checkpoint (Version = 1, no PreviousCheckpointID)
+	checkpoint := &CheckpointEventPayload{
+		Version:   1,
+		Subject:   subject,
+		SubjectID: subjectID,
+		Observation: NaraObservation{
+			StartTime:   1624066568,
+			Restarts:    47,
+			TotalUptime: 23456789,
+		},
+		AsOfTime: time.Now().Unix(),
+		Round:    1,
+	}
+
+	// Add voter signatures using v1 attestation format
+	for i, voterID := range voterIDs {
+		attestation := Attestation{
+			Version:     1,
+			Subject:     subject,
+			SubjectID:   subjectID,
+			Observation: checkpoint.Observation,
+			AttesterID:  voterID,
+			AsOfTime:    checkpoint.AsOfTime,
+		}
+
+		signature := SignContent(&attestation, keypairs[i])
+		checkpoint.VoterIDs = append(checkpoint.VoterIDs, voterID)
+		checkpoint.Signatures = append(checkpoint.Signatures, signature)
+	}
+
+	// Verify v1 checkpoint with v1 signatures
+	lookup := PublicKeyLookup(func(id, name string) ed25519.PublicKey {
+		if pubKeyStr, ok := publicKeys[id]; ok {
+			return pubKeyFromBase64(pubKeyStr)
+		}
+		return nil
+	})
+
+	result := checkpoint.VerifySignatureWithCounts(lookup)
+
+	if !result.Valid {
+		t.Errorf("V1 checkpoint verification failed: valid=%v, validCount=%d, totalCount=%d",
+			result.Valid, result.ValidCount, result.TotalCount)
+	}
+
+	if result.ValidCount != 3 {
+		t.Errorf("Expected 3 valid signatures, got %d", result.ValidCount)
+	}
+
+	// Test ContentString format for v1
+	contentStr := checkpoint.ContentString()
+	expectedPrefix := "checkpoint:" + subjectID
+	if len(contentStr) < len(expectedPrefix) || contentStr[:len(expectedPrefix)] != expectedPrefix {
+		t.Errorf("V1 ContentString has wrong format: %s", contentStr)
+	}
+
+	// V1 format should NOT contain "v2" prefix
+	if len(contentStr) > 12 && contentStr[:12] == "checkpoint:v" {
+		t.Errorf("V1 ContentString should not have version prefix, got: %s", contentStr)
+	}
+}
+
+// TestCheckpointV1WithVersionZero tests that Version=0 is treated as v1
+func TestCheckpointV1WithVersionZero(t *testing.T) {
+	subject := "lisa"
+	subjectID := "lisa-id-abc"
+	voterIDs := []string{"homer-id", "marge-id"}
+	keypairs := make([]NaraKeypair, 2)
+	for i := range keypairs {
+		keypairs[i] = generateTestKeypair()
+	}
+
+	// Create checkpoint with Version = 0 (should be treated as v1)
+	checkpoint := &CheckpointEventPayload{
+		Version:   0,
+		Subject:   subject,
+		SubjectID: subjectID,
+		Observation: NaraObservation{
+			StartTime:   1624066568,
+			Restarts:    47,
+			TotalUptime: 23456789,
+		},
+		AsOfTime: time.Now().Unix(),
+		Round:    1,
+	}
+
+	// Sign with v1 attestation (Version 0 treated as 1)
+	for i, voterID := range voterIDs {
+		attestation := Attestation{
+			Version:     0,
+			Subject:     subject,
+			SubjectID:   subjectID,
+			Observation: checkpoint.Observation,
+			AttesterID:  voterID,
+			AsOfTime:    checkpoint.AsOfTime,
+		}
+
+		signature := SignContent(&attestation, keypairs[i])
+		checkpoint.VoterIDs = append(checkpoint.VoterIDs, voterID)
+		checkpoint.Signatures = append(checkpoint.Signatures, signature)
+	}
+
+	// Verify
+	lookup := PublicKeyLookup(func(id, name string) ed25519.PublicKey {
+		for i, voterID := range voterIDs {
+			if id == voterID {
+				return keypairs[i].PublicKey
+			}
+		}
+		return nil
+	})
+
+	result := checkpoint.VerifySignatureWithCounts(lookup)
+	if !result.Valid {
+		t.Errorf("Version 0 checkpoint verification failed")
+	}
+}
+
+// TestCheckpointV2Format tests the v2 checkpoint format and signature
+func TestCheckpointV2Format(t *testing.T) {
+	subject := "lisa"
+	subjectID := "lisa-id-abc"
+	previousCheckpointID := "prev-checkpoint-123"
+	voterIDs := []string{"homer-id", "marge-id"}
+	keypairs := make([]NaraKeypair, 2)
+	for i := range keypairs {
+		keypairs[i] = generateTestKeypair()
+	}
+
+	// Create v2 checkpoint with PreviousCheckpointID
+	checkpoint := &CheckpointEventPayload{
+		Version:              2,
+		Subject:              subject,
+		SubjectID:            subjectID,
+		PreviousCheckpointID: previousCheckpointID,
+		Observation: NaraObservation{
+			StartTime:   1624066568,
+			Restarts:    47,
+			TotalUptime: 23456789,
+		},
+		AsOfTime: time.Now().Unix(),
+		Round:    1,
+	}
+
+	// Sign with v2 attestation (includes LastSeenCheckpointID)
+	for i, voterID := range voterIDs {
+		attestation := Attestation{
+			Version:              2,
+			Subject:              subject,
+			SubjectID:            subjectID,
+			Observation:          checkpoint.Observation,
+			AttesterID:           voterID,
+			AsOfTime:             checkpoint.AsOfTime,
+			LastSeenCheckpointID: previousCheckpointID,
+		}
+
+		signature := SignContent(&attestation, keypairs[i])
+		checkpoint.VoterIDs = append(checkpoint.VoterIDs, voterID)
+		checkpoint.Signatures = append(checkpoint.Signatures, signature)
+	}
+
+	// Verify v2 checkpoint
+	lookup := PublicKeyLookup(func(id, name string) ed25519.PublicKey {
+		for i, voterID := range voterIDs {
+			if id == voterID {
+				return keypairs[i].PublicKey
+			}
+		}
+		return nil
+	})
+
+	result := checkpoint.VerifySignatureWithCounts(lookup)
+	if !result.Valid {
+		t.Errorf("V2 checkpoint verification failed: valid=%v, validCount=%d",
+			result.Valid, result.ValidCount)
+	}
+
+	// Test ContentString format for v2
+	contentStr := checkpoint.ContentString()
+	expectedPrefix := "checkpoint:v2:" + subjectID
+	if len(contentStr) < len(expectedPrefix) || contentStr[:len(expectedPrefix)] != expectedPrefix {
+		t.Errorf("V2 ContentString has wrong format, expected prefix '%s', got: %s",
+			expectedPrefix, contentStr)
+	}
+
+	// V2 ContentString should include previous checkpoint ID
+	if len(contentStr) < len(previousCheckpointID) ||
+		contentStr[len(contentStr)-len(previousCheckpointID):] != previousCheckpointID {
+		t.Errorf("V2 ContentString should end with previous checkpoint ID '%s', got: %s",
+			previousCheckpointID, contentStr)
+	}
+}
+
+// TestCheckpointV2TamperDetection tests that tampering with PreviousCheckpointID breaks signature
+func TestCheckpointV2TamperDetection(t *testing.T) {
+	subject := "lisa"
+	subjectID := "lisa-id-abc"
+	previousCheckpointID := "prev-checkpoint-123"
+	voterIDs := []string{"homer-id", "marge-id"}
+	keypairs := make([]NaraKeypair, 2)
+	for i := range keypairs {
+		keypairs[i] = generateTestKeypair()
+	}
+
+	// Create v2 checkpoint
+	checkpoint := &CheckpointEventPayload{
+		Version:              2,
+		Subject:              subject,
+		SubjectID:            subjectID,
+		PreviousCheckpointID: previousCheckpointID,
+		Observation: NaraObservation{
+			StartTime:   1624066568,
+			Restarts:    47,
+			TotalUptime: 23456789,
+		},
+		AsOfTime: time.Now().Unix(),
+		Round:    1,
+	}
+
+	// Sign with correct previous checkpoint ID
+	for i, voterID := range voterIDs {
+		attestation := Attestation{
+			Version:              2,
+			Subject:              subject,
+			SubjectID:            subjectID,
+			Observation:          checkpoint.Observation,
+			AttesterID:           voterID,
+			AsOfTime:             checkpoint.AsOfTime,
+			LastSeenCheckpointID: previousCheckpointID,
+		}
+
+		signature := SignContent(&attestation, keypairs[i])
+		checkpoint.VoterIDs = append(checkpoint.VoterIDs, voterID)
+		checkpoint.Signatures = append(checkpoint.Signatures, signature)
+	}
+
+	// Verify it works with correct previous ID
+	lookup := PublicKeyLookup(func(id, name string) ed25519.PublicKey {
+		for i, voterID := range voterIDs {
+			if id == voterID {
+				return keypairs[i].PublicKey
+			}
+		}
+		return nil
+	})
+
+	result := checkpoint.VerifySignatureWithCounts(lookup)
+	if !result.Valid {
+		t.Fatal("Initial v2 checkpoint should verify successfully")
+	}
+
+	// Now tamper with PreviousCheckpointID
+	checkpoint.PreviousCheckpointID = "tampered-checkpoint-999"
+
+	// Verification should fail because signed content changed
+	result = checkpoint.VerifySignatureWithCounts(lookup)
+	if result.Valid {
+		t.Error("Tampered v2 checkpoint should fail verification")
+	}
+
+	if result.ValidCount != 0 {
+		t.Errorf("Expected 0 valid signatures after tampering, got %d", result.ValidCount)
+	}
+}
+
+// TestCheckpointV2FirstCheckpoint tests v2 checkpoint with empty PreviousCheckpointID
+func TestCheckpointV2FirstCheckpoint(t *testing.T) {
+	subject := "lisa"
+	subjectID := "lisa-id-abc"
+	voterIDs := []string{"homer-id", "marge-id"}
+	keypairs := make([]NaraKeypair, 2)
+	for i := range keypairs {
+		keypairs[i] = generateTestKeypair()
+	}
+
+	// Create v2 checkpoint with empty PreviousCheckpointID (first checkpoint)
+	checkpoint := &CheckpointEventPayload{
+		Version:              2,
+		Subject:              subject,
+		SubjectID:            subjectID,
+		PreviousCheckpointID: "", // Empty for first checkpoint
+		Observation: NaraObservation{
+			StartTime:   1624066568,
+			Restarts:    47,
+			TotalUptime: 23456789,
+		},
+		AsOfTime: time.Now().Unix(),
+		Round:    1,
+	}
+
+	// Sign with empty LastSeenCheckpointID
+	for i, voterID := range voterIDs {
+		attestation := Attestation{
+			Version:              2,
+			Subject:              subject,
+			SubjectID:            subjectID,
+			Observation:          checkpoint.Observation,
+			AttesterID:           voterID,
+			AsOfTime:             checkpoint.AsOfTime,
+			LastSeenCheckpointID: "", // Empty for first checkpoint
+		}
+
+		signature := SignContent(&attestation, keypairs[i])
+		checkpoint.VoterIDs = append(checkpoint.VoterIDs, voterID)
+		checkpoint.Signatures = append(checkpoint.Signatures, signature)
+	}
+
+	// Verify first v2 checkpoint
+	lookup := PublicKeyLookup(func(id, name string) ed25519.PublicKey {
+		for i, voterID := range voterIDs {
+			if id == voterID {
+				return keypairs[i].PublicKey
+			}
+		}
+		return nil
+	})
+
+	result := checkpoint.VerifySignatureWithCounts(lookup)
+	if !result.Valid {
+		t.Errorf("First v2 checkpoint (empty previous ID) should verify successfully")
+	}
+
+	// ContentString should end with empty string (likely "::")
+	contentStr := checkpoint.ContentString()
+	expectedPrefix := "checkpoint:v2:" + subjectID
+	if len(contentStr) < len(expectedPrefix) || contentStr[:len(expectedPrefix)] != expectedPrefix {
+		t.Errorf("V2 ContentString has wrong format: %s", contentStr)
+	}
+}
+
+// TestAttestationV1Format tests v1 attestation SignableContent format
+func TestAttestationV1Format(t *testing.T) {
+	attestation := Attestation{
+		Version:    1,
+		SubjectID:  "subject-123",
+		AttesterID: "attester-456",
+		Observation: NaraObservation{
+			StartTime:   1624066568,
+			Restarts:    47,
+			TotalUptime: 23456789,
+		},
+		AsOfTime: time.Now().Unix(),
+	}
+
+	content := attestation.SignableContent()
+
+	// v1 format: attestation:v1:{attester_id}:{subject_id}:{as_of_time}:{restarts}:{uptime}:{first_seen}
+	expectedPrefix := "attestation:v1:"
+	if len(content) < len(expectedPrefix) || content[:len(expectedPrefix)] != expectedPrefix {
+		t.Errorf("V1 attestation has wrong format prefix, got: %s", content)
+	}
+
+	// Should NOT contain LastSeenCheckpointID field
+	// Count colons: v1 format has exactly 7 colons
+	colonCount := 0
+	for _, c := range content {
+		if c == ':' {
+			colonCount++
+		}
+	}
+	if colonCount != 7 {
+		t.Errorf("V1 attestation should have 7 colons, got %d in: %s", colonCount, content)
+	}
+}
+
+// TestAttestationV2Format tests v2 attestation SignableContent format
+func TestAttestationV2Format(t *testing.T) {
+	lastSeenCheckpointID := "prev-checkpoint-789"
+
+	attestation := Attestation{
+		Version:              2,
+		SubjectID:            "subject-123",
+		AttesterID:           "attester-456",
+		LastSeenCheckpointID: lastSeenCheckpointID,
+		Observation: NaraObservation{
+			StartTime:   1624066568,
+			Restarts:    47,
+			TotalUptime: 23456789,
+		},
+		AsOfTime: time.Now().Unix(),
+	}
+
+	content := attestation.SignableContent()
+
+	// v2 format: attestation:v2:{attester_id}:{subject_id}:{as_of_time}:{restarts}:{uptime}:{first_seen}:{last_seen_checkpoint_id}
+	expectedPrefix := "attestation:v2:"
+	if len(content) < len(expectedPrefix) || content[:len(expectedPrefix)] != expectedPrefix {
+		t.Errorf("V2 attestation has wrong format prefix, got: %s", content)
+	}
+
+	// Should end with LastSeenCheckpointID
+	if len(content) < len(lastSeenCheckpointID) ||
+		content[len(content)-len(lastSeenCheckpointID):] != lastSeenCheckpointID {
+		t.Errorf("V2 attestation should end with '%s', got: %s", lastSeenCheckpointID, content)
+	}
+
+	// Count colons: v2 format has exactly 8 colons (one more than v1)
+	colonCount := 0
+	for _, c := range content {
+		if c == ':' {
+			colonCount++
+		}
+	}
+	if colonCount != 8 {
+		t.Errorf("V2 attestation should have 8 colons, got %d in: %s", colonCount, content)
+	}
+}
+
+// TestGetLatestCheckpointID tests the ledger helper for getting latest checkpoint ID
+func TestGetLatestCheckpointID(t *testing.T) {
+	ledger := NewSyncLedger(1000)
+	subject := "lisa"
+
+	// No checkpoint exists yet
+	latestID := ledger.GetLatestCheckpointID(subject)
+	if latestID != "" {
+		t.Errorf("Expected empty string for non-existent checkpoint, got: %s", latestID)
+	}
+
+	// Add first checkpoint
+	checkpoint1 := NewTestCheckpointEvent(subject, time.Now().Unix()-1000, 1624066568, 47, 23456789)
+	ledger.AddEvent(checkpoint1)
+
+	latestID = ledger.GetLatestCheckpointID(subject)
+	if latestID == "" {
+		t.Error("Expected checkpoint ID, got empty string")
+	}
+	if latestID != checkpoint1.ID {
+		t.Errorf("Expected checkpoint ID %s, got %s", checkpoint1.ID, latestID)
+	}
+
+	// Add second checkpoint with later AsOfTime
+	checkpoint2 := NewTestCheckpointEvent(subject, time.Now().Unix(), 1624066568, 50, 24000000)
+	ledger.AddEvent(checkpoint2)
+
+	latestID = ledger.GetLatestCheckpointID(subject)
+	if latestID != checkpoint2.ID {
+		t.Errorf("Expected latest checkpoint ID %s, got %s", checkpoint2.ID, latestID)
+	}
+
+	// Different subject should have no checkpoint
+	otherLatestID := ledger.GetLatestCheckpointID("homer")
+	if otherLatestID != "" {
+		t.Errorf("Expected empty string for different subject, got: %s", otherLatestID)
+	}
+}

--- a/docs/src/content/docs/EVENTS.md
+++ b/docs/src/content/docs/EVENTS.md
@@ -120,11 +120,18 @@ type SocialEventPayload struct {
 
 Checkpoints are multi-party attested snapshots of historical state. They anchor restart counts and uptime from before proper event tracking began. Checkpoints are created through MQTT-based consensus where naras propose and vote on values.
 
+**V2 Enhancement (Chain of Trust)**: Checkpoints now form a verifiable chain by linking to previous checkpoints. Voters must agree on their reference point (which checkpoint they've seen) for consensus to be reached.
+
 ```go
 type CheckpointEventPayload struct {
+    Version     int      // Format version: 1 (legacy) or 2 (with chain)
+
     // Identity (who this checkpoint is about)
     Subject     string   // Nara name
     SubjectID   string   // Nara ID (for indexing)
+
+    // Chain of trust (v2+)
+    PreviousCheckpointID string // ID of previous checkpoint for this subject (empty for first)
 
     // The agreed-upon state (embedded pure data)
     Observation NaraObservation // Contains: Restarts, TotalUptime, StartTime
@@ -153,6 +160,8 @@ type NaraObservation struct {
 - **Historical anchor**: Allows deriving restart count as `checkpoint.Observation.Restarts + count(new restarts)`
 - **MQTT consensus**: Created via proposal/vote flow over MQTT topics
 - **Attestation-based**: Uses Attestation type for signed claims during voting
+- **Chained (v2+)**: Each checkpoint links to the previous one, forming a verifiable chain of history
+- **Reference point consensus (v2+)**: Voters must agree on which checkpoint they're building upon
 
 ## Personality Filtering
 

--- a/http_inspector.go
+++ b/http_inspector.go
@@ -200,17 +200,19 @@ func (ln *LocalNara) inspectorCheckpointsHandler(w http.ResponseWriter, r *http.
 	ln.SyncLedger.mu.RUnlock()
 
 	type CheckpointSummary struct {
-		Subject       string `json:"subject"`
-		SubjectID     string `json:"subject_id"`
-		AsOfTime      int64  `json:"as_of_time"`
-		Round         int    `json:"round"`
-		Restarts      int64  `json:"restarts"`
-		TotalUptime   int64  `json:"total_uptime"`
-		StartTime     int64  `json:"start_time"`
-		VoterCount    int    `json:"voter_count"`
-		VerifiedCount int    `json:"verified_count"`
-		KnownCount    int    `json:"known_count"`
-		Verified      bool   `json:"verified"`
+		Subject              string `json:"subject"`
+		SubjectID            string `json:"subject_id"`
+		AsOfTime             int64  `json:"as_of_time"`
+		Round                int    `json:"round"`
+		Restarts             int64  `json:"restarts"`
+		TotalUptime          int64  `json:"total_uptime"`
+		StartTime            int64  `json:"start_time"`
+		VoterCount           int    `json:"voter_count"`
+		VerifiedCount        int    `json:"verified_count"`
+		KnownCount           int    `json:"known_count"`
+		Verified             bool   `json:"verified"`
+		Version              int    `json:"version"`                          // v2: checkpoint version
+		PreviousCheckpointID string `json:"previous_checkpoint_id,omitempty"` // v2: chain link
 	}
 
 	checkpoints := make([]CheckpointSummary, 0)
@@ -238,17 +240,19 @@ func (ln *LocalNara) inspectorCheckpointsHandler(w http.ResponseWriter, r *http.
 		}
 
 		checkpoints = append(checkpoints, CheckpointSummary{
-			Subject:       checkpoint.Subject,
-			SubjectID:     checkpoint.SubjectID,
-			AsOfTime:      checkpoint.AsOfTime,
-			Round:         checkpoint.Round,
-			Restarts:      checkpoint.Observation.Restarts,
-			TotalUptime:   checkpoint.Observation.TotalUptime,
-			StartTime:     checkpoint.Observation.StartTime,
-			VoterCount:    len(checkpoint.VoterIDs),
-			VerifiedCount: result.ValidCount,
-			KnownCount:    result.KnownCount,
-			Verified:      result.Valid,
+			Subject:              checkpoint.Subject,
+			SubjectID:            checkpoint.SubjectID,
+			AsOfTime:             checkpoint.AsOfTime,
+			Round:                checkpoint.Round,
+			Restarts:             checkpoint.Observation.Restarts,
+			TotalUptime:          checkpoint.Observation.TotalUptime,
+			StartTime:            checkpoint.Observation.StartTime,
+			VoterCount:           len(checkpoint.VoterIDs),
+			VerifiedCount:        result.ValidCount,
+			KnownCount:           result.KnownCount,
+			Verified:             result.Valid,
+			Version:              checkpoint.Version,
+			PreviousCheckpointID: checkpoint.PreviousCheckpointID,
 		})
 	}
 

--- a/identity_attestation.go
+++ b/identity_attestation.go
@@ -26,6 +26,9 @@ type Attestation struct {
 	Attester   string `json:"attester"`    // Nara name making the attestation
 	AttesterID string `json:"attester_id"` // Nara ID (public key hash)
 
+	// Reference point (v2+) - what checkpoint attester had seen when making this attestation
+	LastSeenCheckpointID string `json:"last_seen_checkpoint_id,omitempty"` // ID of last checkpoint attester has seen for subject (empty for v1)
+
 	// When & Proof
 	AsOfTime  int64  `json:"as_of_time"` // Unix timestamp of the checkpoint snapshot (all attesters sign the same time)
 	Signature string `json:"signature"`  // Ed25519 signature of the attestation
@@ -37,18 +40,35 @@ func (a *Attestation) IsSelfAttestation() bool {
 }
 
 // SignableContent returns the canonical string representation for signing/verification
-// Format: "attestation:v{version}:{attester_id}:{subject_id}:{as_of_time}:{restarts}:{total_uptime}:{first_seen}"
+// Version-aware: v1 uses original format, v2 includes reference point (last seen checkpoint)
+// v1 format: "attestation:v1:{attester_id}:{subject_id}:{as_of_time}:{restarts}:{total_uptime}:{first_seen}"
+// v2 format: "attestation:v2:{attester_id}:{subject_id}:{as_of_time}:{restarts}:{total_uptime}:{first_seen}:{last_seen_checkpoint_id}"
 func (a *Attestation) SignableContent() string {
 	version := a.Version
 	if version == 0 {
 		version = 1 // Default to v1 for backwards compatibility
 	}
-	return fmt.Sprintf("attestation:v%d:%s:%s:%d:%d:%d:%d",
+
+	// v1 format (unchanged for backwards compatibility)
+	if version == 1 {
+		return fmt.Sprintf("attestation:v%d:%s:%s:%d:%d:%d:%d",
+			version,
+			a.AttesterID,
+			a.SubjectID,
+			a.AsOfTime,
+			a.Observation.Restarts,
+			a.Observation.TotalUptime,
+			a.Observation.StartTime)
+	}
+
+	// v2 format: includes last seen checkpoint ID for consensus on reference point
+	return fmt.Sprintf("attestation:v%d:%s:%s:%d:%d:%d:%d:%s",
 		version,
 		a.AttesterID,
 		a.SubjectID,
 		a.AsOfTime,
 		a.Observation.Restarts,
 		a.Observation.TotalUptime,
-		a.Observation.StartTime)
+		a.Observation.StartTime,
+		a.LastSeenCheckpointID)
 }

--- a/integration_checkpoint_v2_test.go
+++ b/integration_checkpoint_v2_test.go
@@ -1,0 +1,218 @@
+//go:build !short
+// +build !short
+
+package nara
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// TestCheckpointV2DivergentReferencePointsNoConsensus tests that when naras have different
+// LastSeenCheckpointIDs, they can't reach consensus (votes don't group together)
+func TestCheckpointV2DivergentReferencePointsNoConsensus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	port := 11887
+	naraNames := []string{"test-proposer", "voter1", "voter2", "voter3", "voter4", "voter5"}
+
+	// Start all naras
+	naras := startTestNaras(t, port, naraNames, true)
+
+	// Create different checkpoint histories for each nara by manually adding checkpoints
+	// Each nara will have seen a different previous checkpoint
+	for i, ln := range naras {
+		// Create fake previous checkpoint with unique ID for each nara
+		prevCheckpoint := NewTestCheckpointEvent("test-proposer", time.Now().Unix()-100000, time.Now().Unix()-200000, 10, 50000)
+		// Modify the event ID to make it unique per nara (simulate different checkpoint history)
+		prevCheckpoint.ID = prevCheckpoint.ID + "-nara-" + string(rune('a'+i))
+		ln.SyncLedger.AddEvent(prevCheckpoint)
+		logrus.Infof("Added fake checkpoint %s to %s's ledger", prevCheckpoint.ID, ln.Me.Name)
+	}
+
+	// Give time for checkpoint histories to settle
+	time.Sleep(200 * time.Millisecond)
+
+	// Trigger checkpoint proposal from first nara
+	proposer := naras[0]
+	proposer.Network.checkpointService.ProposeCheckpoint()
+
+	// Wait for vote window + processing
+	time.Sleep(2 * time.Second)
+
+	// Verify NO checkpoint was created (no consensus reached)
+	checkpoint := proposer.SyncLedger.GetCheckpoint("test-proposer")
+
+	// The old checkpoint should still be there, but no NEW checkpoint
+	// We can tell by checking the AsOfTime - new one would be much more recent
+	if checkpoint != nil && checkpoint.AsOfTime > time.Now().Unix()-50 {
+		t.Error("Expected no new checkpoint due to divergent reference points, but found one")
+	}
+
+	logrus.Info("✅ Divergent reference points correctly prevented consensus")
+
+	// Cleanup
+	for _, ln := range naras {
+		ln.Network.Shutdown()
+	}
+}
+
+// TestCheckpointV2NetworkDisagreesWithProposer tests that when the proposer has a different
+// reference point than all voters, but voters agree among themselves, checkpoint is still emitted
+func TestCheckpointV2NetworkDisagreesWithProposer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	port := 11888
+	naraNames := []string{"test-proposer", "voter1", "voter2", "voter3", "voter4", "voter5"}
+
+	// Start all naras
+	naras := startTestNaras(t, port, naraNames, true)
+
+	proposer := naras[0]
+	voters := naras[1:]
+
+	// Give proposer a unique previous checkpoint
+	proposerPrevCheckpoint := NewTestCheckpointEvent("test-proposer", time.Now().Unix()-100000, time.Now().Unix()-200000, 10, 50000)
+	proposerPrevCheckpoint.ID = proposerPrevCheckpoint.ID + "-proposer-unique"
+	proposer.SyncLedger.AddEvent(proposerPrevCheckpoint)
+	logrus.Infof("Added proposer checkpoint %s", proposerPrevCheckpoint.ID)
+
+	// Give all voters the SAME previous checkpoint (different from proposer)
+	voterPrevCheckpoint := NewTestCheckpointEvent("test-proposer", time.Now().Unix()-100000, time.Now().Unix()-200000, 10, 50000)
+	voterPrevCheckpoint.ID = voterPrevCheckpoint.ID + "-voter-shared"
+	for _, voter := range voters {
+		voter.SyncLedger.AddEvent(voterPrevCheckpoint)
+	}
+	logrus.Infof("Added shared checkpoint %s to all voters", voterPrevCheckpoint.ID)
+
+	// Give time for checkpoint histories to settle
+	time.Sleep(200 * time.Millisecond)
+
+	// Trigger checkpoint proposal
+	proposer.Network.checkpointService.ProposeCheckpoint()
+
+	// Wait for vote window + processing
+	time.Sleep(2 * time.Second)
+
+	// Verify checkpoint WAS created (voters formed consensus)
+	checkpoint := proposer.SyncLedger.GetCheckpoint("test-proposer")
+
+	if checkpoint == nil {
+		t.Fatal("Expected checkpoint to be created with voter consensus")
+	}
+
+	// Verify it's a recent checkpoint (within last 5 seconds)
+	if checkpoint.AsOfTime < time.Now().Unix()-5 {
+		t.Error("Checkpoint is too old, expected recent checkpoint")
+	}
+
+	// Verify it has v2 format with PreviousCheckpointID
+	if checkpoint.Version != 2 {
+		t.Errorf("Expected v2 checkpoint, got version %d", checkpoint.Version)
+	}
+
+	// The previous checkpoint ID should be the voters' shared ID (not proposer's)
+	if checkpoint.PreviousCheckpointID != voterPrevCheckpoint.ID {
+		t.Errorf("Expected checkpoint to use voters' reference point %s, got %s",
+			voterPrevCheckpoint.ID, checkpoint.PreviousCheckpointID)
+	}
+
+	// Verify proposer's signature is NOT included (different reference point)
+	proposerIncluded := false
+	for _, voterID := range checkpoint.VoterIDs {
+		if voterID == proposer.Me.Status.ID {
+			proposerIncluded = true
+			break
+		}
+	}
+	if proposerIncluded {
+		t.Error("Proposer's signature should NOT be included (different reference point)")
+	}
+
+	logrus.Info("✅ Network consensus worked despite proposer disagreement")
+
+	// Cleanup
+	for _, ln := range naras {
+		ln.Network.Shutdown()
+	}
+}
+
+// TestCheckpointV1ToV2Chain tests that a new v2 checkpoint correctly points to an existing v1 checkpoint
+func TestCheckpointV1ToV2Chain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	port := 11889
+	naraNames := []string{"test-nara", "voter1", "voter2", "voter3", "voter4", "voter5"}
+
+	// Start all naras
+	naras := startTestNaras(t, port, naraNames, true)
+
+	testNara := naras[0]
+
+	// Create a v1 checkpoint manually
+	v1Checkpoint := NewTestCheckpointEvent("test-nara", time.Now().Unix()-100, time.Now().Unix()-200, 10, 50000)
+	v1Checkpoint.Checkpoint.Version = 1
+	v1Checkpoint.Checkpoint.PreviousCheckpointID = "" // v1 has no previous ID
+	v1Checkpoint.ComputeID()                          // Recompute ID for v1 format
+
+	// Add v1 checkpoint to all naras
+	for _, ln := range naras {
+		ln.SyncLedger.AddEvent(v1Checkpoint)
+	}
+	logrus.Infof("Added v1 checkpoint %s to all naras", v1Checkpoint.ID)
+
+	// Give time for checkpoint to be processed
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify v1 checkpoint exists
+	existingCheckpoint := testNara.SyncLedger.GetCheckpoint("test-nara")
+	if existingCheckpoint == nil {
+		t.Fatal("V1 checkpoint not found")
+	}
+	if existingCheckpoint.Version != 1 {
+		t.Errorf("Expected v1 checkpoint, got version %d", existingCheckpoint.Version)
+	}
+
+	// Trigger new checkpoint proposal (should create v2)
+	testNara.Network.checkpointService.ProposeCheckpoint()
+
+	// Wait for vote window + processing
+	time.Sleep(2 * time.Second)
+
+	// Verify new v2 checkpoint was created
+	newCheckpoint := testNara.SyncLedger.GetCheckpoint("test-nara")
+	if newCheckpoint == nil {
+		t.Fatal("Expected new checkpoint to be created")
+	}
+
+	// Verify it's v2
+	if newCheckpoint.Version != 2 {
+		t.Errorf("Expected v2 checkpoint, got version %d", newCheckpoint.Version)
+	}
+
+	// Verify it points to the v1 checkpoint
+	if newCheckpoint.PreviousCheckpointID != v1Checkpoint.ID {
+		t.Errorf("Expected v2 checkpoint to point to v1 checkpoint %s, got %s",
+			v1Checkpoint.ID, newCheckpoint.PreviousCheckpointID)
+	}
+
+	// Verify it's recent
+	if newCheckpoint.AsOfTime < time.Now().Unix()-5 {
+		t.Error("New checkpoint is too old")
+	}
+
+	logrus.Info("✅ V1 to V2 chain works correctly")
+
+	// Cleanup
+	for _, ln := range naras {
+		ln.Network.Shutdown()
+	}
+}

--- a/nara-web/src/ProfileView.jsx
+++ b/nara-web/src/ProfileView.jsx
@@ -272,7 +272,7 @@ export function ProfileView({ name }) {
             onClick={openCheckpointModal}
             style={{ cursor: 'pointer' }}
           >
-            <h3><i className="iconoir-camera"></i> Checkpoint</h3>
+            <h3><i className="iconoir-camera"></i> Checkpoint {checkpoint.version && checkpoint.version > 1 && <span className="version-badge">v{checkpoint.version}</span>}</h3>
             <div className="checkpoint-observations">
               <div className="observation-item">
                 <span className="observation-label">Restarts:</span>
@@ -291,6 +291,11 @@ export function ProfileView({ name }) {
               {checkpoint.verified_count} of {checkpoint.voter_count} signatures verified
               {checkpoint.all_verified && ' ✓'}
             </div>
+            {checkpoint.previous_checkpoint_id && (
+              <div className="checkpoint-chain-indicator">
+                🔗 Chained to previous checkpoint
+              </div>
+            )}
             <div className="checkpoint-hint">Click to view details</div>
           </div>
         )}
@@ -443,10 +448,36 @@ export function ProfileView({ name }) {
             <div className="modal-body">
               <div className="detail-section">
                 <div className="detail-label">SUMMARY</div>
+                <div>Version: {checkpointModal.event?.checkpoint?.version || 1}</div>
                 <div>Total Voters: {checkpointModal.summary?.total_voters}</div>
                 <div>Verified: {checkpointModal.summary?.verified_voters}</div>
                 <div>Self-Attestation: {checkpointModal.summary?.is_self_attestation ? 'Yes' : 'No'}</div>
               </div>
+
+              {checkpointModal.event?.checkpoint?.previous_checkpoint_id && (
+                <div className="detail-section checkpoint-chain-section">
+                  <div className="detail-label">CHAIN OF TRUST</div>
+                  <div className="checkpoint-chain-info">
+                    <div className="chain-item current">
+                      <div className="chain-icon">📍</div>
+                      <div className="chain-details">
+                        <div className="chain-label">Current Checkpoint</div>
+                        <div className="chain-id">{checkpointModal.event?.id?.substring(0, 12)}...</div>
+                        <div className="chain-time">{new Date(checkpointModal.event?.checkpoint?.as_of_time * 1000).toLocaleString()}</div>
+                      </div>
+                    </div>
+                    <div className="chain-arrow">↓</div>
+                    <div className="chain-item previous">
+                      <div className="chain-icon">🔗</div>
+                      <div className="chain-details">
+                        <div className="chain-label">Previous Checkpoint</div>
+                        <div className="chain-id">{checkpointModal.event?.checkpoint?.previous_checkpoint_id?.substring(0, 12)}...</div>
+                        <div className="chain-note">Verifiable chain link</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
 
               <div className="detail-section">
                 <div className="detail-label">VOTERS</div>

--- a/nara-web/src/app.css
+++ b/nara-web/src/app.css
@@ -427,6 +427,107 @@ body::before {
   box-shadow: 0 4px 12px rgba(102, 126, 234, 0.2);
 }
 
+/* Checkpoint v2 chain visualization */
+.version-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: 2px 8px;
+  border-radius: 12px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+.checkpoint-chain-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: #667eea;
+  background: rgba(102, 126, 234, 0.08);
+  padding: 6px 10px;
+  border-radius: 8px;
+  margin-top: 8px;
+  font-weight: 500;
+}
+
+.checkpoint-chain-section {
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.05) 0%, rgba(118, 75, 162, 0.05) 100%);
+  padding: 16px;
+  border-radius: 12px;
+  margin-top: 16px;
+}
+
+.checkpoint-chain-info {
+  margin-top: 12px;
+}
+
+.chain-item {
+  display: flex;
+  align-items: start;
+  gap: 12px;
+  padding: 12px;
+  background: white;
+  border-radius: 10px;
+  border: 2px solid rgba(102, 126, 234, 0.2);
+}
+
+.chain-item.current {
+  border-color: #667eea;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.15);
+}
+
+.chain-item.previous {
+  border-color: #e0e0e0;
+  opacity: 0.85;
+}
+
+.chain-icon {
+  font-size: 24px;
+  line-height: 1;
+}
+
+.chain-details {
+  flex: 1;
+}
+
+.chain-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #999;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.chain-id {
+  font-family: 'Monaco', 'Courier New', monospace;
+  font-size: 13px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 2px;
+}
+
+.chain-time {
+  font-size: 11px;
+  color: #666;
+}
+
+.chain-note {
+  font-size: 11px;
+  color: #667eea;
+  font-weight: 500;
+}
+
+.chain-arrow {
+  text-align: center;
+  font-size: 20px;
+  color: #667eea;
+  padding: 8px 0;
+}
+
 .voter-list {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
This pull request implements version 2 (v2) of the checkpoint protocol, introducing a "chain of trust" by linking each checkpoint to the previous one via a reference ID. This ensures checkpoints form a verifiable, tamper-evident chain and that consensus is only reached when all voters agree on the reference point (the last checkpoint seen). The update includes changes to the core checkpoint logic, attestation/signature formats, documentation, and adds comprehensive integration tests for the new behaviors.

**Core protocol and data structure changes:**

* Added `PreviousCheckpointID` field to `CheckpointEventPayload` and `LastSeenCheckpointID` to `Attestation` to support chaining of checkpoints and reference point consensus. The checkpoint and attestation formats are now versioned (v1 for legacy, v2 for chained). (`checkpoint_types.go` [[1]](diffhunk://#diff-0e1fba1e154a311b53ed8e4018af7d857d574726926809c71daa017d7a40008aR31-R33) [[2]](diffhunk://#diff-0e1fba1e154a311b53ed8e4018af7d857d574726926809c71daa017d7a40008aR50-R68) [[3]](diffhunk://#diff-e8b40281ca70421d375cb1dcd6a5acf9e440ffe0eb122b9f22e9d20c3825a4d9R29-R31) [[4]](diffhunk://#diff-e8b40281ca70421d375cb1dcd6a5acf9e440ffe0eb122b9f22e9d20c3825a4d9L40-R53) [[5]](diffhunk://#diff-e8b40281ca70421d375cb1dcd6a5acf9e440ffe0eb122b9f22e9d20c3825a4d9R63-R74)
* Updated all checkpoint creation, proposal, attestation, consensus, and storage logic to use and require the reference point fields in v2, ensuring that consensus can only be reached if all votes reference the same previous checkpoint. (`checkpoint_service.go` [[1]](diffhunk://#diff-bd8a959e24148c7e5add572b99c35d33407de1697b0dfda7a3c5b8db9313be42R243-R248) [[2]](diffhunk://#diff-bd8a959e24148c7e5add572b99c35d33407de1697b0dfda7a3c5b8db9313be42R259) [[3]](diffhunk://#diff-bd8a959e24148c7e5add572b99c35d33407de1697b0dfda7a3c5b8db9313be42R349-R351) [[4]](diffhunk://#diff-bd8a959e24148c7e5add572b99c35d33407de1697b0dfda7a3c5b8db9313be42L360-R374) [[5]](diffhunk://#diff-bd8a959e24148c7e5add572b99c35d33407de1697b0dfda7a3c5b8db9313be42L554-R588) [[6]](diffhunk://#diff-bd8a959e24148c7e5add572b99c35d33407de1697b0dfda7a3c5b8db9313be42R633-R636) [[7]](diffhunk://#diff-bd8a959e24148c7e5add572b99c35d33407de1697b0dfda7a3c5b8db9313be42L631-R653) [[8]](diffhunk://#diff-bd8a959e24148c7e5add572b99c35d33407de1697b0dfda7a3c5b8db9313be42L698-R731)

**Signature and verification updates:**

* Modified the canonical content string for both checkpoints and attestations to include the reference point in v2, ensuring signatures are bound to the checkpoint chain. Updated signature verification logic accordingly. (`checkpoint_types.go` [[1]](diffhunk://#diff-0e1fba1e154a311b53ed8e4018af7d857d574726926809c71daa017d7a40008aR50-R68) [[2]](diffhunk://#diff-0e1fba1e154a311b53ed8e4018af7d857d574726926809c71daa017d7a40008aR147-R151); `identity_attestation.go` [[3]](diffhunk://#diff-e8b40281ca70421d375cb1dcd6a5acf9e440ffe0eb122b9f22e9d20c3825a4d9L40-R53) [[4]](diffhunk://#diff-e8b40281ca70421d375cb1dcd6a5acf9e440ffe0eb122b9f22e9d20c3825a4d9R63-R74)

**Documentation:**

* Updated checkpoint event documentation to describe the v2 "chain of trust" enhancement, new fields, and consensus requirements. (`docs/src/content/docs/EVENTS.md` [[1]](diffhunk://#diff-b3ae27e2ffa79876eab97274ffa07019a5deaefe23955783051efa82858b3f15R123-R135) [[2]](diffhunk://#diff-b3ae27e2ffa79876eab97274ffa07019a5deaefe23955783051efa82858b3f15R163-R164)

**Testing:**

* Added integration tests to verify v2 behaviors, including: (a) no consensus when reference points diverge, (b) consensus when voters agree even if proposer disagrees, and (c) correct chaining from v1 to v2 checkpoints. (`integration_checkpoint_v2_test.go` [integration_checkpoint_v2_test.goR1-R218](diffhunk://#diff-7aa73f5361a459ce37a43e639e9a0f47ed52347d4c8381ab6658082fa2cc083dR1-R218))

**Other:**

* Exposed new checkpoint fields in the HTTP inspector API for debugging/inspection. (`http_inspector.go` [[1]](diffhunk://#diff-962ee6fc2d62d0c64914430c98b462be910ee48aa48f99ad31d4392eb1ac547dR214-R215) [[2]](diffhunk://#diff-962ee6fc2d62d0c64914430c98b462be910ee48aa48f99ad31d4392eb1ac547dR254-R255)
* Minor: Added `find` command to allowed commands in `.claude/settings.local.json`.